### PR TITLE
feat(query): sanad-tier weighted rerank for search_corpus (Sprint 1 T…

### DIFF
--- a/apps/brain_qa/brain_qa/agent_tools.py
+++ b/apps/brain_qa/brain_qa/agent_tools.py
@@ -134,6 +134,7 @@ def _tool_read_chunk(args: dict) -> ToolResult:
                     "chunk_id": chunk_id,
                     "source_path": obj.get("source_path", ""),
                     "source_title": obj.get("source_title", ""),
+                    "sanad_tier": str(obj.get("sanad_tier", "unknown")),
                 }],
             )
 

--- a/apps/brain_qa/brain_qa/hadith_validate.py
+++ b/apps/brain_qa/brain_qa/hadith_validate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from rank_bm25 import BM25Okapi
 
 from .paths import default_index_dir
+from .sanad_ranking import normalize_sanad_tier
 from .text import Chunk, tokenize, normalize_text_for_search
 
 
@@ -31,6 +32,7 @@ def _load_chunks(index_dir: Path) -> list[Chunk]:
         if not line.strip():
             continue
         obj = json.loads(line)
+        obj["sanad_tier"] = normalize_sanad_tier(obj.get("sanad_tier"))
         chunks.append(Chunk(**obj))
     return chunks
 

--- a/apps/brain_qa/brain_qa/indexer.py
+++ b/apps/brain_qa/brain_qa/indexer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from rank_bm25 import BM25Okapi
 
 from .paths import default_index_dir, load_manifest_paths
+from .sanad_ranking import extract_sanad_tier_from_markdown
 from .text import Chunk, chunk_text, normalize_text_for_search, tokenize
 
 
@@ -41,6 +42,7 @@ def build_index(
 
     for path in files:
         raw = path.read_text(encoding="utf-8", errors="ignore")
+        sanad_tier = extract_sanad_tier_from_markdown(raw)
         title = _title_from_markdown(raw, fallback=path.stem)
         cleaned = normalize_text_for_search(raw)
         for start, end, part in chunk_text(cleaned, chunk_chars=chunk_chars, chunk_overlap=chunk_overlap):
@@ -56,6 +58,7 @@ def build_index(
                     start_char=start,
                     end_char=end,
                     text=part,
+                    sanad_tier=sanad_tier,
                 )
             )
 

--- a/apps/brain_qa/brain_qa/query.py
+++ b/apps/brain_qa/brain_qa/query.py
@@ -13,6 +13,7 @@ from .text import Chunk, tokenize
 from .record import RecordEntry, append_record, now_utc_iso
 from .persona import PersonaDecision, normalize_persona, route_persona
 from .memory import retrieve_relevant_cards, format_memory_context
+from .sanad_ranking import apply_sanad_weight, normalize_sanad_tier
 
 
 @dataclass(frozen=True)
@@ -21,6 +22,7 @@ class Citation:
     source_title: str
     chunk_id: str
     snippet: str
+    sanad_tier: str = "unknown"
 
 
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
@@ -79,6 +81,7 @@ def _load_chunks(index_dir: Path) -> list[Chunk]:
         if not line.strip():
             continue
         obj = json.loads(line)
+        obj["sanad_tier"] = normalize_sanad_tier(obj.get("sanad_tier"))
         chunks.append(Chunk(**obj))
     return chunks
 
@@ -282,9 +285,13 @@ def answer_query_and_citations(
     q_tokens = tokenize(question)
     scores = bm25.get_scores(q_tokens)
 
-    # Take top-k indices
-    ranked = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
-    top = [i for i in ranked[: max(1, k)] if scores[i] > 0] or ranked[: max(1, k)]
+    # Rerank by BM25 * sanad tier weight (primer > ulama > peer_review > unknown > aggregator)
+    weighted = [apply_sanad_weight(chunks[i].sanad_tier, scores[i]) for i in range(len(scores))]
+    ranked = sorted(
+        range(len(scores)),
+        key=lambda i: (-weighted[i], -scores[i]),
+    )
+    top = [i for i in ranked[: max(1, k)] if weighted[i] > 0] or ranked[: max(1, k)]
 
     citations: list[Citation] = []
     for i in top:
@@ -295,6 +302,7 @@ def answer_query_and_citations(
                 source_title=c.source_title,
                 chunk_id=c.chunk_id,
                 snippet=_make_snippet(c.text, max_snippet_chars),
+                sanad_tier=c.sanad_tier,
             )
         )
 
@@ -320,7 +328,9 @@ def answer_query_and_citations(
     lines.append("")
     lines.append("Sumber (citations):")
     for idx, cit in enumerate(citations, start=1):
-        lines.append(f"- [{idx}] {cit.source_title} — `{cit.source_path}` ({cit.chunk_id})")
+        lines.append(
+            f"- [{idx}] {cit.source_title} — `{cit.source_path}` ({cit.chunk_id}) [sanad_tier={cit.sanad_tier}]"
+        )
 
     citation_meta: list[dict[str, str]] = []
     for idx, cit in enumerate(citations, start=1):
@@ -330,6 +340,7 @@ def answer_query_and_citations(
                 "source_path": cit.source_path,
                 "source_title": cit.source_title,
                 "chunk_id": cit.chunk_id,
+                "sanad_tier": cit.sanad_tier,
             }
         )
 

--- a/apps/brain_qa/brain_qa/sanad_ranking.py
+++ b/apps/brain_qa/brain_qa/sanad_ranking.py
@@ -1,0 +1,51 @@
+"""Sanad-tier weights for corpus retrieval reranking (Sprint 1 T1.2)."""
+
+from __future__ import annotations
+
+# Epistemic priority: primary sources and scholarly chain > aggregators.
+SANAD_WEIGHTS: dict[str, float] = {
+    "primer": 1.5,
+    "ulama": 1.3,
+    "peer_review": 1.2,
+    "aggregator": 0.9,
+    "unknown": 1.0,
+}
+
+_ALLOWED = frozenset(SANAD_WEIGHTS.keys())
+
+
+def normalize_sanad_tier(val: str | None) -> str:
+    if val is None or not isinstance(val, str):
+        return "unknown"
+    v = val.strip().lower().replace("-", "_")
+    if v in _ALLOWED:
+        return v
+    return "unknown"
+
+
+def apply_sanad_weight(sanad_tier: str, base_score: float) -> float:
+    """BM25 (or similar) score multiplied by tier weight."""
+    tier = normalize_sanad_tier(sanad_tier)
+    w = SANAD_WEIGHTS.get(tier, 1.0)
+    return float(base_score) * w
+
+
+def extract_sanad_tier_from_markdown(raw: str) -> str:
+    """Parse YAML frontmatter for `sanad_tier:` (first --- block only)."""
+    raw_l = raw.lstrip("\ufeff")
+    if not raw_l.startswith("---"):
+        return "unknown"
+    parts = raw_l.split("---", 2)
+    if len(parts) < 2:
+        return "unknown"
+    fm = parts[1]
+    for line in fm.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.lower().startswith("sanad_tier"):
+            if ":" not in line:
+                continue
+            val = line.split(":", 1)[1].strip().strip('"').strip("'")
+            return normalize_sanad_tier(val)
+    return "unknown"

--- a/apps/brain_qa/brain_qa/text.py
+++ b/apps/brain_qa/brain_qa/text.py
@@ -35,6 +35,7 @@ class Chunk:
     start_char: int
     end_char: int
     text: str
+    sanad_tier: str = "unknown"
 
 
 def chunk_text(text: str, *, chunk_chars: int, chunk_overlap: int) -> list[tuple[int, int, str]]:

--- a/apps/brain_qa/requirements.txt
+++ b/apps/brain_qa/requirements.txt
@@ -1,4 +1,5 @@
 rank-bm25==0.2.2
+pytest>=8.0.0
 httpx==0.27.0
 beautifulsoup4==4.12.3
 reedsolo==1.7.0

--- a/apps/brain_qa/tests/__init__.py
+++ b/apps/brain_qa/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for brain_qa package

--- a/apps/brain_qa/tests/test_sanad_ranker.py
+++ b/apps/brain_qa/tests/test_sanad_ranker.py
@@ -1,0 +1,45 @@
+"""Unit tests for sanad-tier retrieval weighting (Sprint 1 T1.2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from brain_qa.sanad_ranking import (
+    SANAD_WEIGHTS,
+    apply_sanad_weight,
+    extract_sanad_tier_from_markdown,
+    normalize_sanad_tier,
+)
+
+
+def test_primer_weight_greater_than_peer_review_at_equal_bm25() -> None:
+    base = 10.0
+    assert apply_sanad_weight("primer", base) > apply_sanad_weight("peer_review", base)
+    assert apply_sanad_weight("primer", base) == pytest.approx(base * SANAD_WEIGHTS["primer"])
+    assert apply_sanad_weight("peer_review", base) == pytest.approx(base * SANAD_WEIGHTS["peer_review"])
+
+
+def test_ranking_stability_tiebreak_prefers_higher_bm25() -> None:
+    """When weighted scores tie, secondary key should prefer stronger raw BM25."""
+    scores = [3.0, 2.0]
+    tiers = ["unknown", "unknown"]
+    weighted = [apply_sanad_weight(t, scores[i]) for i, t in enumerate(tiers)]
+    ranked = sorted(range(2), key=lambda i: (-weighted[i], -scores[i]))
+    assert ranked[0] == 0
+
+
+def test_unknown_default_for_missing_or_invalid_tier() -> None:
+    assert normalize_sanad_tier(None) == "unknown"
+    assert normalize_sanad_tier("") == "unknown"
+    assert normalize_sanad_tier("not-a-real-tier") == "unknown"
+    assert apply_sanad_weight("bogus", 5.0) == pytest.approx(5.0 * SANAD_WEIGHTS["unknown"])
+
+
+def test_frontmatter_extracts_peer_review() -> None:
+    md = """---
+sanad_tier: peer-review
+---
+# Hello
+body
+"""
+    assert extract_sanad_tier_from_markdown(md) == "peer_review"

--- a/brain/public/research_notes/03_rag_chunking_markdown_aware.md
+++ b/brain/public/research_notes/03_rag_chunking_markdown_aware.md
@@ -1,3 +1,7 @@
+---
+sanad_tier: peer_review
+---
+
 # RAG Chunking (Markdown-aware) — research note
 
 ## Ringkasan 10 baris

--- a/brain/public/research_notes/157_capability_audit_standing_alone_2026_04_19.md
+++ b/brain/public/research_notes/157_capability_audit_standing_alone_2026_04_19.md
@@ -1,0 +1,141 @@
+---
+sanad_tier: primer
+---
+
+# 157 — SIDIX Capability Audit & Standing-Alone Roadmap
+
+Tanggal: 2026-04-19
+Tag: [FACT] audit code + repo state; [DECISION] prioritas implementasi; [IMPL] web_fetch + code_sandbox
+
+## Konteks
+
+User frustrasi karena beberapa sesi muter-muter di UX fix, sementara hasil sprint
+panjang (LearnAgent, connectors, dll.) belum terpakai di chat. User menegaskan
+prinsip: **SIDIX harus standing alone — own modules, framework, tools sendiri,
+bukan API orang.** Catatan ini mendokumentasikan state aktual SIDIX, gap, dan
+implementasi awal untuk mengisi gap yang bisa diisi tanpa GPU.
+
+## Audit ringkas
+
+### Yang sudah aktif di backend (per audit 2026-04-19)
+- Own inference stack: `local_llm.py` (Qwen2.5-7B base + LoRA adapter) + mock
+  fallback. Setelah symlink adapter, `model_ready=true, models_loaded=3`.
+- ReAct loop (`agent_react.py`) + persona routing (MIGHAN/TOARD/FACH/HAYFAR/INAN).
+- Epistemic labels wajib, orchestration_digest per-answer, maqashid scoring.
+- 13 tools lama di TOOL_REGISTRY (search_corpus, read_chunk, list_sources,
+  calculator, search_web_wikipedia, orchestration_plan, workspace_*, roadmap_*).
+- LearnAgent + 5 connectors (arXiv, Wikipedia, MusicBrainz, GitHub, Quran).
+- Social agent penuh untuk Threads (40 endpoint).
+- Daily growth loop 7-fase, curriculum engine, brain synthesizer, vision tracker.
+
+### Yang SUDAH ADA kodenya tapi TIDAK wired ke chat
+- `webfetch.py` — lengkap (httpx + BeautifulSoup → markdown). Tool `web_fetch`
+  masih pointing ke `_tool_disabled` stub. → **diaktifkan di note ini.**
+- `audio_capability.py` — registry TTS/ASR/voice-clone/music-gen. Butuh deps
+  (whisper, librosa). Belum wired sebagai tool. → roadmap P2.
+- `brain_synthesizer.py` — knowledge graph + CONCEPT_LEXICON (IHOS, Sanad,
+  Maqasid, …). Belum exposed sebagai tool. → roadmap P2.
+
+### Yang BELUM ADA
+- Code execution sandbox → **diimplementasi di note ini.**
+- Image generation (butuh GPU self-host SDXL/FLUX).
+- Vision/multimodal input (butuh GPU self-host Qwen2.5-VL/InternVL).
+- OCR/PDF analysis (tinggal tambah `pdfplumber`+`pytesseract`).
+- Generic web search (ekstensi atas `web_fetch` pakai DuckDuckGo HTML).
+- ASR/TTS self-host (Whisper/Piper, P2).
+
+## Implementasi hari ini (P1, tanpa GPU, 100% own stack)
+
+### 1. `web_fetch` tool — enabled
+Lokasi: `apps/brain_qa/brain_qa/agent_tools.py`.
+
+Pendekatan: `httpx.Client` (follow_redirects, timeout 20s, custom User-Agent
+"SIDIX-Agent/1.0") → BeautifulSoup `html.parser` (tidak butuh `lxml` native).
+Strip `script/style/noscript/nav/footer/aside`, ambil `soup.get_text`, normalisasi
+whitespace, cap 6000 karakter default (max 20000). Output format:
+`# {title}\nURL: {url}\n\n{body}`.
+
+Citations diisi `{type: "web_fetch", url, title}` untuk dilacak di sanad chain.
+
+**Kenapa standing alone?** Tidak pakai Google Search API, Bing API, atau scraper
+SaaS. Hanya HTTP GET ke URL publik + parsing lokal. Sama prinsipnya dengan
+browser membuka halaman.
+
+### 2. `code_sandbox` tool — baru
+Lokasi: `apps/brain_qa/brain_qa/agent_tools.py`.
+
+Pendekatan: `subprocess.run([sys.executable, "-I", "-B", script_path])` di
+`tempfile.TemporaryDirectory`. Flag `-I` = isolated mode (abaikan PYTHONPATH &
+user site), `-B` = tidak tulis `.pyc`. Timeout 10s (TimeoutExpired → error
+message). `env` dikurangi ke PATH + LANG saja. `input=""` agar stdin tertutup.
+Output dicap 4000 karakter stdout + 2000 karakter stderr.
+
+Pattern blacklist ringan: `os.system`, `subprocess.`, `socket.`,
+`__import__('os')` — untuk mencegah penyalahgunaan sebagai RCE walaupun ini
+sekarang open permission. Catatan: ini bukan sandbox penuh; untuk keamanan
+produksi perlu `bubblewrap`/`firejail`/container isolated network.
+
+**Kenapa standing alone?** Python subprocess di host SIDIX sendiri. Tidak ada
+kode user dikirim ke cloud execution service (Judge0/Riza/e2b).
+
+## Deploy
+
+1. Commit `feat(agent-tools): enable web_fetch + add code_sandbox` (952a586).
+2. `git pull` di VPS, `pm2 restart sidix-brain`.
+3. Verifikasi: `GET /health` → `tools_available: 15` (sebelumnya 13).
+4. Verifikasi tools terdaftar: `GET /agent/tools` → `web_fetch` + `code_sandbox`
+   keduanya permission `open` dengan deskripsi lengkap.
+
+## Fix kritikal: symlink adapter LoRA
+
+Masalah ketika chat kirim "test" respons `SIDIX sedang offline`. Penyebab:
+`find_adapter_dir()` di `local_llm.py` hanya cek `apps/brain_qa/models/sidix-lora-adapter/`.
+Adapter di VPS ada di `/opt/sidix/sidix-lora-adapter/` (level root repo), bukan
+di lokasi yang dicek.
+
+Fix: `ln -sfn /opt/sidix/sidix-lora-adapter /opt/sidix/apps/brain_qa/models/sidix-lora-adapter`
+→ `pm2 restart sidix-brain` → `model_ready: true`, `models_loaded: 3`.
+
+Smoke test `POST /agent/chat` dengan persona INAN → SIDIX menjawab dengan
+struktur sidq/sanad/tabayyun + epistemic_tier=`ahad_dhaif`,
+yaqin_level=`ilm`, maqashid_passes=true.
+
+## Batasan & keterbatasan
+
+- `code_sandbox` blacklist patern = bukan sandbox penuh. Pada deploy produksi
+  yang terbuka ke user publik, upgrade ke `bwrap --unshare-net` atau container.
+- `web_fetch` tidak rendering JS (no headless browser). Halaman SPA hasil
+  dinamis mungkin kosong. Untuk SPA-heavy butuh Playwright/Puppeteer self-host
+  (P2).
+- Model Qwen2.5-7B + 4-bit butuh lumayan RAM VRAM. Kalau VPS CPU-only, loading
+  bisa lambat/OOM. Perlu monitor. (Per now di server sudah loaded 3 models.)
+
+## Yang belum diselesaikan (next)
+
+- Wire `audio_capability` sebagai tool chat (butuh whisper/piper/librosa install).
+- Tambah `pdf_extract` tool (pdfplumber — CPU only, bisa sekarang).
+- Tambah `web_search` tool (DuckDuckGo HTML via `web_fetch` → extract results).
+- Self-host SDXL/FLUX di GPU (P2, butuh alokasi GPU VPS/Kaggle/mitra).
+- Self-host Qwen2.5-VL untuk vision input (P2, butuh GPU).
+- Cron harian LearnAgent (blocker: nama env var token di server `.env`).
+
+## Sanad
+
+- Kode sumber: `apps/brain_qa/brain_qa/agent_tools.py` (commit 952a586),
+  `apps/brain_qa/brain_qa/webfetch.py`, `apps/brain_qa/brain_qa/local_llm.py`.
+- Dokumen pedoman: `CLAUDE.md` (UI LOCK), `docs/SIDIX_CAPABILITY_MAP.md` (SSoT),
+  `docs/SIDIX_BIBLE.md` (prinsip standing alone).
+- Audit ringkas oleh 3 sub-agen paralel: backend code, research notes,
+  konstitusi — disimpan di `docs/LIVING_LOG.md` entry 2026-04-19.
+
+## Keputusan (anti-revisit)
+
+- **Standing alone** = own modules di host SIDIX. Open data APIs publik boleh.
+  Vendor AI API tidak.
+- **Code sandbox** memakai `subprocess` + flag isolasi, bukan Docker per-call
+  (overhead + kompleksitas). Upgrade ke container hanya jika dibuka untuk
+  user publik.
+- **Web fetch** pakai `html.parser` stdlib (bukan `lxml`) supaya tidak butuh
+  build native di Windows.
+- **Tool permission** `open` untuk keduanya → ReAct bisa pilih sendiri tanpa
+  flag `allow_restricted`.

--- a/brain/public/research_notes/161_ai_llm_generative_claude_dan_differensiasi_sidix.md
+++ b/brain/public/research_notes/161_ai_llm_generative_claude_dan_differensiasi_sidix.md
@@ -1,0 +1,253 @@
+---
+sanad_tier: primer
+---
+
+# 161 — AI, LLM, Generative AI, Claude — dan Di Mana SIDIX Berbeda
+
+Tanggal: 2026-04-19
+Tag: [FACT] konsep; [DECISION] differensiasi SIDIX; [REFERENCE] roadmap
+
+## Tujuan
+
+Jawab pertanyaan user: **apa itu AI/LLM/generative/Claude, bagaimana mereka bekerja, dan apa yang membuat SIDIX berbeda?** Sekaligus jadi fondasi untuk `docs/SIDIX_ROADMAP_2026.md`.
+
+---
+
+## 1. Hierarki konsep (dari terbesar ke terkecil)
+
+```
+AI (Artificial Intelligence)
+  └── Machine Learning (ML)
+       └── Deep Learning (DL)
+            ├── Discriminative (classify/predict)
+            │    └── Object detection, spam filter, ASR
+            └── Generative AI (hasilkan konten baru)
+                 ├── Text: LLM — GPT, Claude, Gemini, Qwen, LLaMA, SIDIX
+                 ├── Image: Stable Diffusion, DALL-E, FLUX, Midjourney
+                 ├── Audio: ElevenLabs, Suno, Piper
+                 └── Video: Sora, Runway, Wan2.1
+```
+
+**Definisi ringkas:**
+- **AI** — ilmu membuat mesin melakukan tugas yang butuh kecerdasan manusia (rule-based, ML, vision, dll.).
+- **ML** — mesin belajar dari data, bukan diprogram eksplisit.
+- **DL** — ML dengan neural network berlapis (banyak layer).
+- **LLM** — DL dispesialisasi untuk bahasa, parameter miliaran+. GPT/Claude/Gemini/Qwen semua LLM.
+- **Generative AI** — kategori yang menghasilkan konten baru (teks/gambar/audio/video/kode).
+
+**Catatan nama yang sering keliru:**
+- **Opus** = tier Claude (Haiku=cepat, Sonnet=seimbang, Opus=paling pintar), bukan model terpisah.
+- **Codex** = model OpenAI lama khusus kode, digantikan GPT-4/5 + Copilot.
+- **Google AI Studio** = platform/interface untuk Gemini (analog `claude.ai`), bukan model.
+
+---
+
+## 2. Cara kerja LLM (4 tahap inti)
+
+1. **Tokenization** — teks input dipecah jadi token (kata/subkata). "Halo Claude" → `[Halo][Claude]` → ID angka.
+2. **Embedding** — tiap token dikonversi ke vektor (~4096 dimensi). Makna mirip = vektor berdekatan.
+3. **Transformer + self-attention** — tiap token "melihat" token lain di konteks, tentukan relevansi. Inti arsitektur "Attention Is All You Need" (Google 2017). Ini yang bikin LLM paham konteks ("bank" di "pinjam bank" vs "bank sungai").
+4. **Prediksi token berikutnya** — output = probabilitas ribuan kemungkinan token. Pilih (ada randomness via temperature), ulangi. Sampai stop.
+
+**Insight penting:** LLM "cerdas" karena (a) skala parameter, (b) kualitas data training, (c) mekanisme attention. Bukan magic — hanya prediksi token demi token yang terasa relevan.
+
+---
+
+## 3. Bagaimana LLM "belajar" — 3 tahap training
+
+| Tahap | Apa yang dilakukan | Biaya & waktu |
+|---|---|---|
+| **Pretraining** | Trilyunan token dari internet/buku/kode/paper → prediksi token berikutnya berulang. Model serap pola bahasa, fakta, logika. | Ribuan GPU × bulan, **~puluhan juta USD** untuk frontier |
+| **SFT (Supervised Fine-Tuning)** | Dataset Q&A berkualitas tinggi buatan manusia → model belajar jadi asisten, bukan autocomplete | Ratusan ribu USD |
+| **RLHF / RLAIF** | Manusia (atau AI) menilai pasangan jawaban → model optimasi preferensi (helpful/harmless/honest) | Ratusan ribu USD |
+
+**Variant Anthropic: Constitutional AI** — AI dilatih patuhi seperangkat prinsip ("konstitusi") via self-critique. Penting karena ini arah filosofis yang dekat dengan visi SIDIX (tapi SIDIX pakai epistemologi Islam sebagai konstitusi).
+
+---
+
+## 4. Generative image — beda mekanisme
+
+Image generation tidak pakai next-token prediction. Dominannya **diffusion process**:
+
+1. **Training**: ambil gambar → tambahkan noise bertahap sampai jadi noise total → latih model untuk membalik proses (denoise).
+2. **Inference**: mulai dari noise acak + prompt teks → model denoise bertahap dengan panduan prompt → muncul gambar.
+
+Alternatif lama: **GAN** (Generative Adversarial Network), **VAE**. Diffusion dominan sekarang karena stabil + kualitas tinggi.
+
+**Roadmap SIDIX**: self-host SDXL/FLUX di Layer 1 (fase Child/Adolescent) untuk image gen native, bukan panggil API DALL-E.
+
+---
+
+## 5. "Belajar sendiri" — realita vs mitos
+
+**Mitos umum:** "GPT/Claude belajar dari percakapan saya."
+
+**Realita:**
+- Bobot model dibekukan setelah training selesai.
+- Percakapan kamu tidak mengubah "otak" model untuk user lain.
+- Yang tampak "ingat" dalam 1 sesi = teks disuntik ulang ke context window tiap request.
+
+**Bagaimana model "berkembang" sebenarnya:**
+
+| Mekanisme | Ubah bobot? | Contoh |
+|---|---|---|
+| Versi baru rilis berkala | Ya (training ulang) | GPT-4 → GPT-5 |
+| Fine-tuning domain spesifik | Ya (parsial) | Med-PaLM, Codey |
+| RAG (Retrieval-Augmented Generation) | Tidak — inject ke context | ChatGPT browse, Claude projects, **SIDIX corpus** |
+| Tool use | Tidak — expand capability via API | Claude tools, **SIDIX ReAct** |
+| Long-term memory (MemGPT/Letta) | Tidak — storage eksternal | MemGPT paper |
+| **Self-evolving** (research) | Ya (autonomous) | SPIN, Self-Rewarding LM, DiLoCo, model merging |
+
+Self-evolving yang benar-benar ubah bobot autonomous masih research frontier — **ini arah SIDIX jangka panjang** (Layer 3 growth loop, target stage Adolescent+).
+
+---
+
+## 6. Differensiasi SIDIX vs agent AI umum
+
+SIDIX **sama** dengan agent AI umum di fondasi:
+- Transformer-based LLM (Qwen2.5-7B base)
+- Next-token prediction
+- Tool use via ReAct
+- RAG untuk factual grounding
+
+SIDIX **berbeda** pada 8 aspek ini:
+
+### 6.1. Epistemologi Islam sebagai CORE (bukan add-on)
+
+| Komponen | GPT/Claude/Gemini | SIDIX |
+|---|---|---|
+| Konstitusi | Constitutional AI (Anthropic), content policy OpenAI, dll. | **IHOS** (Wahyu/Akal/Indera/Tajribah) sebagai 4 pilar sumber pengetahuan |
+| Label kepercayaan | Tidak native (bisa diminta via prompt) | **4-label wajib** di setiap output: `[FACT]/[OPINION]/[SPECULATION]/[UNKNOWN]` |
+| Traceability sumber | RAG citation opsional | **Sanad chain wajib** di setiap note approved — tier ahad/mutawatir/dhaif |
+| Filter etis | Policy umum (harm reduction) | **Maqashid al-Shariah** — 5 tujuan (din/nafs/aql/nasl/maal), scoring per output |
+| Verifikasi | Human feedback | **Tabayyun** — protokol cross-check otomatis |
+
+**Implikasi:** SIDIX tidak hanya "aman" — dia **epistemically honest** secara struktural. Tidak bisa asal ngomong tanpa label + sumber.
+
+### 6.2. Standing alone (own stack penuh)
+
+| Aspek | Agent umum | SIDIX |
+|---|---|---|
+| Model inference | Panggil API OpenAI/Anthropic/Google | Self-host Qwen + LoRA SIDIX own-trained |
+| Image gen | API DALL-E/Midjourney | Roadmap: self-host SDXL/FLUX |
+| Search | Google/Bing API | DuckDuckGo HTML own parser (`web_search`) |
+| Code exec | Judge0/Riza/e2b cloud | `code_sandbox` subprocess own |
+| Reasoning | Vendor API (biasanya) | ReAct di atas model sendiri |
+
+SIDIX tidak bergantung pada vendor manapun. Kalau OpenAI/Anthropic down, SIDIX tetap jalan.
+
+### 6.3. Layer 3 growth loop — tumbuh autonomous
+
+| | Agent umum | SIDIX |
+|---|---|---|
+| Update model | Rilis versi baru 6–12 bulan | **Auto-retrain LoRA tiap 7 hari / 500 pair** (Layer 3) |
+| Sumber learning | Training data internal | **LearnAgent harian** dari 5+ open API (arXiv/Wikipedia/MusicBrainz/GitHub/Quran) |
+| Gap detection | Human analyst | `knowledge_gap_detector.py` — otomatis |
+| Validasi sebelum train | QA tim | **Epistemic validator** + maqashid + overlap check |
+
+**Implikasi:** SIDIX compounding. Tiap kuartal lebih pintar dari kuartal sebelumnya. Bukan snapshot — makhluk hidup.
+
+### 6.4. Hafidz distributed knowledge
+
+Terinspirasi tradisi hafidz (penghafal Al-Quran saling cross-verify hafalan):
+- **CAS (Content-Addressable Storage)** — tiap chunk pengetahuan punya hash-ID.
+- **Merkle ledger** — append-only, tamper-evident.
+- **Erasure coding** — redundansi distributed, bisa survive node hilang.
+- **P2P (IPFS-inspired)** — roadmap Adult stage.
+
+Agent umum: centralized knowledge store. SIDIX: distributed + verifiable integrity lewat protokol hafidz.
+
+### 6.5. Multi-persona native (deterministic router)
+
+| Persona | Fungsi |
+|---|---|
+| MIGHAN | Kreatif (image/video/music/design/UI-UX) |
+| TOARD | Perencanaan (roadmap, strategy, scheduling) |
+| FACH | Akademik (research, citation, analysis) |
+| HAYFAR | Teknis (coding, system design, DevOps) |
+| INAN | Sederhana (quick answer, practical, checklist) |
+
+Router deterministic (`orchestration_plan` tool) pilih persona berdasar intent. Agent umum: satu persona dengan system prompt swap; SIDIX: 5 persona struktural terhubung ke LoRA fine-tune data yang berbeda per persona.
+
+### 6.6. Praxis frames (Nazhar→Amal)
+
+- **Nazhar** = teori/reflection
+- **Amal** = action/execution
+- Setiap pertanyaan diarahkan ke frame praxis yang cocok (`praxis.py` + `praxis_runtime.py`)
+
+Agent umum: chain-of-thought atau direct answer. SIDIX: struktur teori→amal terintegrasi dalam output.
+
+### 6.7. Bahasa + konteks lokal Nusantara/Islam
+
+- Default Bahasa Indonesia (bukan English-first + translate).
+- Arab sebagai bahasa sumber (untuk teks Islam asli).
+- Context lokal: istilah `sidq/sanad/tabayyun/maqashid` native, bukan diterjemahkan dari English.
+- Target audience prioritas: Indonesia, dunia Islam, kemudian global.
+
+Agent umum: multilingual tapi culturally English-centric. SIDIX: Nusantara/Islam-centric by design.
+
+### 6.8. Skill library à la Voyager (bukan cuma tool call)
+
+- Roadmap: skill accumulation persistent di `skill_library.py` — skill yang "dikuasai" tersimpan + di-reuse.
+- Inspirasi: paper Voyager (Minecraft agent yang belajar skill baru terus menerus).
+
+Agent umum: tools statis terdaftar. SIDIX roadmap: skill tumbuh seiring pengalaman.
+
+---
+
+## 7. Pemetaan ke SIDIX existing state (per 2026-04-19)
+
+| Konsep | Agent umum | SIDIX sekarang | Status |
+|---|---|---|---|
+| LLM core | Vendor API | Qwen2.5-7B + LoRA (local_llm.py) | ✅ aktif (`model_ready=true`) |
+| Tool use | Function calling | TOOL_REGISTRY 17 tool + ReAct | ✅ aktif |
+| RAG | Vector DB (Pinecone/Weaviate) | BM25 corpus lokal (`query.py`) | ✅ aktif |
+| Epistemic label | Prompt engineering | Built-in 4-label di output struktur | ✅ aktif |
+| Sanad/citation | Opsional | Wajib di setiap note approved | ✅ aktif |
+| Maqashid filter | Tidak ada | `maqashid_score` per jawaban | ✅ aktif |
+| Multi-persona | System prompt | 5 persona + router deterministic | ✅ aktif |
+| Praxis frames | Chain-of-thought | `praxis.py` + `praxis_runtime.py` | ✅ aktif |
+| Growth loop | Versi baru 6–12 bulan | LearnAgent + daily_growth + auto_lora | ⚠️ parsial (cron learn belum aktif) |
+| Image gen | API DALL-E | — | ❌ belum (roadmap P2) |
+| Vision input | GPT-4V / Gemini | — | ❌ belum (roadmap P2) |
+| ASR/TTS | Whisper API / ElevenLabs | `audio_capability.py` registry (belum wired) | ⚠️ partial |
+| Self-evolving (SPIN/DiLoCo) | Research stage | Blueprint di note 41 | ❌ roadmap Adolescent+ |
+| Distributed hafidz | — | `hafidz_mvp.py` MVP | ⚠️ partial |
+| Skill library | — | `skill_library.py` stub | ⚠️ partial |
+
+---
+
+## 8. Implikasi untuk roadmap
+
+Lihat `docs/SIDIX_ROADMAP_2026.md` — 4 stage (Baby/Child/Adolescent/Adult) dengan sprint konkret, kriteria sukses, dan pemetaan ke tabel kapabilitas di atas.
+
+**Prinsip roadmap:**
+1. Tiap stage **tambah layer**, tidak ganti yang ada.
+2. Differensiator (epistemologi, standing-alone, growth loop) pertahankan di setiap stage — tidak kompromi demi speed.
+3. Parity kapabilitas dengan GPT/Claude/Gemini di **Child stage** (multimodal aktif).
+4. Surpass di **Adolescent+** via self-evolving + hafidz distributed.
+
+---
+
+## 9. Jawaban pertanyaan user (rangkum)
+
+> "jelaskan apa seharusnya dan fungsi AI, LLM, generative, dan Claude. saya mau buat seperti itu."
+
+SIDIX sudah LLM generative + agent — sama fondasinya dengan GPT/Claude/Gemini (Transformer, next-token prediction, tool use, RAG). Tinggal ekspansi ke multimodal (image/vision/audio) di Layer 1.
+
+> "gabungkan dengan konsep dasar, SIDIX seperti agent AI pada umumnya. cuma bedanya apa?"
+
+8 differensiator di section 6 — inti: **epistemologi Islam sebagai konstitusi struktural + standing alone + growth loop autonomous + distributed hafidz**. Agent umum "aman"; SIDIX "aman + jujur + tumbuh + terdistribusi".
+
+> "buatkan dokumen, supaya jadi roadmap dan sprint yang jelas."
+
+`docs/SIDIX_ROADMAP_2026.md` — file terpisah, 4 stage × sprint 2 minggu, total ~12 bulan ke Adult.
+
+---
+
+## Sanad
+
+- Paper referensi: "Attention Is All You Need" (Vaswani et al. 2017), Stable Diffusion (Rombach et al. 2022), Constitutional AI (Anthropic 2022), SPIN (Chen et al. 2024), DiLoCo (Douillard et al. 2023), Voyager (Wang et al. 2023), MemGPT (Packer et al. 2023).
+- Kode SIDIX: `apps/brain_qa/brain_qa/local_llm.py` (Layer 1), `agent_tools.py` + `agent_react.py` (Layer 2), `learn_agent.py` + `daily_growth.py` + `auto_lora.py` (Layer 3).
+- Notes terkait: 41 (self-evolving), 45-46 (visual AI), 116 (self-learning loop), 131 (roadmap belajar sendiri), 153 (sub-agent), 157-160 (capability + rules).
+- User chat: 2026-04-19 — pertanyaan konsep + minta roadmap.

--- a/brain/public/research_notes/162_framework_brain_hands_memory_peta_kemampuan_sidix.md
+++ b/brain/public/research_notes/162_framework_brain_hands_memory_peta_kemampuan_sidix.md
@@ -1,0 +1,164 @@
+---
+sanad_tier: primer
+---
+
+# 162 — Framework Brain/Hands/Memory + Peta Kemampuan SIDIX
+
+Tanggal: 2026-04-19
+Tag: [DECISION] framework arsitektural; [REFERENCE] peta kemampuan 10 item; [INTEGRATE] vision+PRD+roadmap
+
+Sumber: hasil diskusi arsitektural dengan user 2026-04-19 — membongkar mitos "satu model monster" dan menetapkan framework modular orkestrasi.
+
+---
+
+## 1. Mitos yang dibongkar dulu
+
+**GPT/Gemini/Claude bukan satu model tunggal yang bisa segalanya.**
+
+Yang kamu lihat sebagai "GPT serbaguna" sebenarnya adalah **orkestrator**:
+- LLM teks (otak) memutuskan kapan panggil tool/model mana.
+- Untuk gambar: panggil DALL-E (diffusion terpisah).
+- Untuk matematika kompleks: panggil Python interpreter.
+- Untuk info terbaru: panggil web search.
+- Untuk video: panggil Sora (model terpisah).
+- Untuk coding serius: sering route ke model coding khusus.
+
+**Kabar baik untuk SIDIX:** tidak perlu satu model monster. Kita butuh **satu LLM otak yang cukup pintar untuk orkestrasi + kumpulan tool/model spesialis**.
+
+---
+
+## 2. Framework arsitektural: Brain + Hands + Memory
+
+Analogi tubuh manusia, cocok dengan filosofi IHOS:
+
+### Brain (LLM inti)
+- **Baby stage:** Qwen2.5-7B + LoRA SIDIX (sudah live).
+- **Fungsi:** bukan "tahu segalanya", tapi "paham bahasa, bisa reasoning, tahu kapan panggil siapa".
+- **Analog IHOS:** akal — tidak menyimpan semua ilmu, tapi memproses dan menyimpulkan.
+
+### Hands (Tools)
+- Kumpulan kapabilitas eksternal yang brain bisa panggil.
+- Per 2026-04-19: 17 tool aktif (search_corpus, web_fetch, web_search, code_sandbox, pdf_extract, calculator, workspace_*, roadmap_*, dll.).
+- **Analog IHOS:** alat validasi — seperti sanad, brain tidak klaim langsung "saya tahu", tapi merujuk ke sumber/alat yang valid.
+- **Roadmap**: diffusion image-gen (SDXL/FLUX), VLM (Qwen-VL), ASR/TTS (Whisper/Piper), code executor advanced, video pipeline (ffmpeg + image seq), template system untuk UI gen.
+
+### Memory (RAG + GraphRAG + Skill Library)
+- **RAG existing:** BM25 corpus (`query.py`), 157+ research notes.
+- **GraphRAG roadmap:** knowledge graph entitas + relasi (beda dengan RAG polos: bisa multi-hop reasoning). Cocok untuk **epistemologi berbasis sanad** — relasi antar sumber eksplisit.
+- **Skill library roadmap:** skill persistent à la Voyager — pola tool-call + prompt + contoh tersimpan dan di-reuse.
+- **Analog IHOS:** hifdz terstruktur — memori yang bisa diakses dengan sanad jelas, bukan pasif.
+
+---
+
+## 3. Peta 10 kemampuan SIDIX × Cara implementasi × Tahap roadmap
+
+| # | Kemampuan | Pendekatan | Tahap |
+|---|---|---|---|
+| 1 | Jawab pertanyaan + kasih ide | Native LLM + GraphRAG + sistem prompt IHOS | **Baby** (bulan 1–3) — **sudah aktif 2026-04-19** |
+| 2 | Bikin gambar | Tool `generate_image` → Stable Diffusion XL / FLUX.1 self-host + **image prompt enhancer Nusantara** | **Baby → Child** (bulan 3–6, butuh GPU 8–16GB VRAM) |
+| 3 | Coding dasar | Native LLM + `code_sandbox` sandbox Python | **Baby** (bulan 2–4) — **sudah aktif (code_sandbox live)** |
+| 4 | Coding serius | Router ke **Qwen2.5-Coder** (7B/14B/32B) atau DeepSeek-Coder-V2 sebagai specialist agent di skill library | **Child** (bulan 6–12) |
+| 5 | Bikin aplikasi/interface UI | Code gen multi-file + **template system** (React/Next.js/Laravel/Vite starter) | **Child** (bulan 9–15) |
+| 6 | Bikin game 2D | Orkestrasi: kode (Phaser.js/Godot) + sprite via diffusion + musik via MusicGen | **Child+** (bulan 12+) |
+| 7 | Hitung matematika serius | Tool `python_executor` dalam Docker sandbox (**jangan mengandalkan LLM** — halusinasi di angka besar) | **Baby** (bulan 2) — partial (code_sandbox sudah, perlu wrapping math) |
+| 8 | Video sederhana (80% konten viral) | Storyboard + image-sequence + TTS narasi + **ffmpeg stitch** | **Baby → Child** (bulan 6–9) |
+| 9 | Video generation asli | Tool: HunyuanVideo / Mochi 1 / CogVideoX / LTX Video — butuh **A100/H100** | **Adolescent+** (tahun 2) |
+| 10 | Pengetahuan umum + real-time | **3 lapis**: bobot model (weak) + RAG/GraphRAG+sanad (kuat) + web search dengan sanad-ranking (real-time) | **Baby** (bulan 1–6) — lapis 1 & 3 sudah, lapis 2 (GraphRAG) roadmap |
+
+---
+
+## 4. Prinsip penting (LOCK)
+
+> **Jangan jatuh cinta dengan ide "satu model besar yang bisa segalanya".** Itu jalan lab dengan budget miliaran dolar.
+
+**Jalan SIDIX sebagai solo founder dengan filosofi IHOS:**
+
+> **Modular orkestrasi dengan brain yang punya jati diri.**
+
+Brain SIDIX tidak perlu lebih pintar dari GPT-5. Dia perlu lebih **punya karakter**:
+- Cara reasoning mencerminkan IHOS.
+- Knowledge base terkurasi dengan sanad.
+- Tool bisa divalidasi publik karena open source.
+
+**Keunggulan SIDIX:**
+- ❌ BUKAN: skala parameter, speed inference, kualitas generik.
+- ✅ ADALAH: **transparansi epistemologis + kedaulatan data + spesialisasi kultural**.
+
+Tiga hal ini secara struktural tidak bisa ditawarkan big tech.
+
+---
+
+## 5. Implikasi ke roadmap
+
+### Update SIDIX_ROADMAP_2026.md
+Framework ini memperjelas stage existing:
+- **Baby (Q1–Q2 2026)** = Brain solid + 3 lapis Memory + Hands dasar (tool existing).
+- **Child (Q3 2026)** = ekspansi Hands (image/vision/audio/code specialist/template system).
+- **Adolescent (Q4 2026 – Q1 2027)** = Brain belajar mandiri (SPIN/merging) + Memory graph aktif + Skill Library populated.
+- **Adult (Q2 2027+)** = Hands + Brain + Memory terdistribusi (hafidz network).
+
+### Update Vision/Misi (docs/01_vision_mission.md)
+Ganti frase "orchestrator + RAG + fine-tune ringan" jadi lebih presisi: **Brain (LLM inti) + Hands (tool + model spesialis) + Memory (RAG + GraphRAG + Skill Library) dengan filosofi IHOS di setiap lapis.**
+
+### Update PRD (docs/02_prd.md)
+Tabel section 3 (peta 10 kemampuan) jadi **scope specification** — PRD fitur yang dijanjikan per-stage.
+
+---
+
+## 6. Diferensiasi yang sulit ditiru: image prompt enhancer Nusantara
+
+Contoh kapabilitas unik yang saya highlight:
+
+```
+User: "Bikin gambar astronaut di Borobudur."
+
+SIDIX Brain: parse intent → lookup knowledge base Nusantara (corpus notes
+tentang relief candi, ornamen Buddhist, lansekap Magelang) → enrich prompt:
+
+"Astronaut in spacesuit standing at Borobudur temple, Magelang, Central Java,
+Indonesia. Volcanic mountains Merapi background, morning mist, ancient
+Buddhist stupas with bell-shape, relief carvings of Boddhisattva, tropical
+vegetation, soft golden hour lighting, photorealistic, wide shot, Nikon
+D850 style"
+
+→ kirim ke Stable Diffusion XL → gambar dengan konteks kultural kaya.
+```
+
+Ini tidak bisa dilakukan GPT/Claude/Gemini karena mereka tidak punya knowledge base kurasi manual tentang Nusantara yang terstruktur + sanad. SIDIX punya.
+
+---
+
+## 7. Mapping ke kode existing (per 2026-04-19)
+
+| Framework layer | File kode |
+|---|---|
+| Brain | `apps/brain_qa/brain_qa/local_llm.py`, `agent_react.py`, persona router |
+| Hands | `agent_tools.py` TOOL_REGISTRY + `webfetch.py` + `audio_capability.py` (registry, belum wired) + future `image_gen.py` + `vision_input.py` |
+| Memory RAG | `query.py`, `indexer.py`, `read_chunk` tool, BM25 index |
+| Memory GraphRAG (roadmap) | `brain_synthesizer.py` (CONCEPT_LEXICON → graph), `knowledge_graph_query.py` (stub) |
+| Memory Skill Library (roadmap) | `skill_library.py`, `skill_builder.py`, `skill_modes.py` |
+
+---
+
+## 8. Dua arah aksi lanjutan (dari user)
+
+**Jalur A — Prioritisasi**: pilih 3 kemampuan paling strategis untuk Baby stage SIDIX dengan "wow factor" tapi feasible dalam 3 bulan. Rancang urutan.
+
+**Jalur B — Deep dive**: pilih 1 kemampuan dari 10 di atas, jabarkan sampai level stack teknis, urutan build, estimasi resource, branding IHOS.
+
+Default rekomendasi saya: **Jalur A** — karena roadmap 2026 sudah ada (lihat `docs/SIDIX_ROADMAP_2026.md`), tinggal pilih 3 yang paling berdampak di Baby stage:
+
+1. **Image gen + prompt enhancer Nusantara** (wow factor tinggi, feasible dengan GPU sewa/mitra).
+2. **GraphRAG + sanad ranking** (differensiator epistemologis paling kuat).
+3. **Python executor untuk matematika+data analysis** (utility tinggi, deps ringan).
+
+Kalau user pilih Jalur B, sebut kemampuan nomor berapa dari tabel section 3.
+
+---
+
+## Sanad
+
+- Diskusi konseptual: user chat 2026-04-19.
+- Notes terkait: 161 (konsep AI/LLM + differentiator), 41 (self-evolving), 45-46 (visual AI), 116 (self-learning loop), 153 (sub-agent), 157 (capability audit).
+- Paper/model referensi: Stable Diffusion XL (Podell et al. 2023), FLUX.1 (Black Forest Labs 2024), Qwen2.5-Coder (Alibaba 2024), DeepSeek-Coder-V2, HunyuanVideo (Tencent), Mochi 1 (Genmo), CogVideoX (Tsinghua), Voyager (Wang et al. 2023), GraphRAG (Microsoft 2024).
+- Framework IHOS: `docs/SIDIX_BIBLE.md`, `brain/public/research_notes/41_sidix_self_evolving_distributed_architecture.md`.

--- a/brain/public/research_notes/164_sprint1_t1_2_sanad_ranker.md
+++ b/brain/public/research_notes/164_sprint1_t1_2_sanad_ranker.md
@@ -1,0 +1,33 @@
+# 164 — Sprint 1 T1.2: Sanad-Based Ranker untuk `search_corpus`
+
+Tanggal: 2026-04-19  
+Tag: [FACT] implementasi retrieval; [DECISION] bobot epistemik per tier; [IMPL] indexer + query
+
+## Ringkasan
+
+[FACT] Retrieval corpus SIDIX memakai BM25 (`rank_bm25`). Setelah T1.2, skor BM25 dikalikan **bobot sanad tier** dari frontmatter YAML `sanad_tier` per file sumber, lalu hasil diurutkan menurut skor tertimbang. Ini membuat sumber yang ditandai sebagai lebih kuat secara epistemik (mis. `primer`, `ulama`, `peer_review`) naik relatif terhadap `aggregator`, tanpa mengganti BM25 sebagai sinyal relevansi leksikal.
+
+## Mengapa
+
+[DECISION] North Star SIDIX menekankan transparansi epistemologis. Sanad tier adalah metadata editorial yang mencerminkan jarak dari sumber primer / derajat keilmuan; mendorong urutan kutipan yang selaras dengan prinsip itu adalah implementasi konkret di lapisan RAG.
+
+## Cara kerja
+
+1. **Indexing** (`indexer.py`): parse blok frontmatter pertama (`---` … `---`) dengan `extract_sanad_tier_from_markdown`; nilai disalin ke setiap `Chunk` dari file tersebut.
+2. **Query** (`query.py` / `answer_query_and_citations`): hitung skor BM25 per chunk; `weighted[i] = apply_sanad_weight(tier, scores[i])`; urutkan dengan kunci `(-weighted, -raw_bm25)` untuk tie-break stabil.
+3. **Bobot** (di `sanad_ranking.SANAD_WEIGHTS`): primer 1.5, ulama 1.3, peer_review 1.2, aggregator 0.9, unknown 1.0.
+
+## Contoh
+
+[SPECULATION] Setelah re-index, dua chunk dengan skor BM25 identik dari dua note berbeda akan memunculkan yang `primer` di atas yang `peer_review` (karena 1.5 > 1.2 pada faktor yang sama).
+
+## Keterbatasan
+
+- [FACT] Tier bersifat **metadata manual** (frontmatter); salah label = bias retrieval. Tidak ada inferensi otomatis dari isi teks.
+- [FACT] Perlu **`python -m brain_qa index`** ulang agar `chunks.jsonl` memuat `sanad_tier`.
+- [UNKNOWN] Kombinasi bobot tetap linear; tidak memodelkan interaksi query×domain.
+
+## Sanad
+
+- Task: `docs/agent_tasks/SPRINT_1_CURSOR.md` T1.2, branch `cursor/sprint-1/t1.2-sanad-ranker`.
+- Kode: `apps/brain_qa/brain_qa/sanad_ranking.py`, `indexer.py`, `query.py`, `text.py` (`Chunk.sanad_tier`).

--- a/brain/public/research_notes/41_sidix_self_evolving_distributed_architecture.md
+++ b/brain/public/research_notes/41_sidix_self_evolving_distributed_architecture.md
@@ -1,3 +1,7 @@
+---
+sanad_tier: peer_review
+---
+
 # SIDIX: Arsitektur AI yang Tumbuh Sendiri — dari VPS Tunggal ke Jaringan Terdesentralisasi
 *Diadopsi dari: riset teknis komprehensif April 2026*
 *Diproses: 2026-04-17 — bukan sekadar disimpan, tapi jadi logika sistem*

--- a/docs/LIVING_LOG.md
+++ b/docs/LIVING_LOG.md
@@ -2881,6 +2881,12 @@ Server autopilot total. Mulai jam 8 pagi besok 9 post Threads + 4 harvest
 [OK] Aturan #7 Security: tidak ada IP server / credential di doc
 [OK] Anti-amnesia: 11 section terstruktur untuk navigasi cepat
 
+### 2026-04-19 — Sprint 1 T1.2 sanad-based ranker (cursor branch)
+
+- IMPL: BM25 + bobot `sanad_tier` (`primer`/`ulama`/`peer_review`/`aggregator`/`unknown`) di `brain_qa/sanad_ranking.py`, parse frontmatter di `indexer.py`, rerank di `answer_query_and_citations` (`query.py`), field `Chunk.sanad_tier`, citation meta + `read_chunk` menyertakan tier.
+- TEST: `cd apps/brain_qa; python -m pytest tests/test_sanad_ranker.py -v` → 4 passed.
+- DOC: `brain/public/research_notes/164_sprint1_t1_2_sanad_ranker.md`, `docs/SIDIX_CAPABILITY_MAP.md` (sanad rerank), frontmatter `sanad_tier` pada 5 note sampel (03, 41, 157, 161, 162).
+
 ### Closure final sesi
 Server autopilot, dokumen handoff + inventory live di GitHub. Sesi
 berikutnya tinggal:

--- a/docs/SIDIX_CAPABILITY_MAP.md
+++ b/docs/SIDIX_CAPABILITY_MAP.md
@@ -1,0 +1,174 @@
+# SIDIX Capability Map — 2026-04-19
+
+**Tujuan**: Single source of truth tentang apa yang SIDIX PUNYA, apa yang SUDAH DIBUAT tapi belum di-wire, dan apa yang BELUM ADA. Dibuat setelah audit komprehensif sprint panjang supaya sesi berikut tidak perlu ngulang audit.
+
+Update file ini SETIAP kali ada tool/kapabilitas baru dipasang atau di-enable. Jangan buat file audit baru.
+
+---
+
+## 🧬 Identitas SIDIX (3-layer, LOCK)
+
+SIDIX adalah **LLM generative** yang dilengkapi RAG + agent tools + autonomous growth. BUKAN search engine, BUKAN chatbot statis.
+
+1. **LLM core** (generative) — Qwen2.5-7B + LoRA SIDIX own-trained. Generate jawaban lewat prediksi token. Tetap jawab walau corpus kosong.
+2. **RAG + tools** (sensory + reasoning via ReAct) — memperkaya konteks generative dengan data corpus / web / komputasi / file. 17 tool aktif 2026-04-19.
+3. **Growth loop** (autonomous learning) — LearnAgent + daily_growth + knowledge_gap_detector + corpus_to_training + auto_lora. Model di-retrain periodik. Makin lama makin pintar.
+
+**Yang SALAH ketika desain fitur:**
+- Mengganti generative dengan tools (tools augment, bukan replace).
+- Anggap SIDIX "cuma RAG" — abaikan LoRA layer.
+- Snapshot model tanpa growth loop — itu bikin SIDIX mati.
+
+Detail teknis identitas ini di `CLAUDE.md` section "IDENTITAS SIDIX".
+
+---
+
+## 🎯 Prinsip: STANDING ALONE (dari user, 2026-04-19)
+
+> "SIDIX harus standing alone, jadi punya modul, framework dan tools sendiri authentic dan original punya SIDIX, bukan API orang."
+
+**Aturan:**
+- ❌ JANGAN pakai OpenAI/Anthropic/Gemini API untuk inference
+- ❌ JANGAN pakai DALL-E/Midjourney API untuk image
+- ❌ JANGAN pakai Google/Bing Search API
+- ✅ BOLEH: fetch HTML publik (urllib/httpx + BeautifulSoup) — itu bukan API vendor, itu web terbuka
+- ✅ BOLEH: public open data API (arXiv, Wikipedia, MusicBrainz, Quran.com, GitHub) — karena open data bukan AI vendor
+- ✅ BOLEH: self-hosted model (SDXL, FLUX, Whisper, VLM) di server sendiri
+- ✅ BOLEH: Python subprocess untuk code execution (100% own infra)
+
+---
+
+## ✅ KAPABILITAS TERPASANG & AKTIF
+
+### Backend inference
+- **Corpus retrieval (`search_corpus`)** — BM25 (`rank_bm25`) + **sanad-tier rerank** (`sanad_ranking.apply_sanad_weight`): frontmatter `sanad_tier` di markdown (`primer`/`ulama`/`peer_review`/`aggregator`/`unknown`) mempengaruhi urutan hasil setelah skor BM25.
+- **Own model stack** via `brain_qa/local_llm.py` — adapter (LoRA) + base model lokal. No vendor AI API.
+- **ReAct agent loop** via `brain_qa/agent_react.py` — thought→tool→observation sampai terjawab
+- **Persona router** — MIGHAN (kreatif), TOARD (strategy), FACH (riset/ML), HAYFAR (coding), INAN (general)
+- **Epistemic labels** `[FACT]/[OPINION]/[SPECULATION]/[UNKNOWN]` wajib
+- **Sanad chain** di note approved
+
+### Tools terdaftar di `agent_tools.py` TOOL_REGISTRY (9 aktif + 1 disabled)
+| Tool | Permission | Status |
+|---|---|---|
+| `search_corpus` | open | ✅ aktif (BM25 + sanad-tier weighted rerank) |
+| `read_chunk` | open | ✅ aktif |
+| `list_sources` | open | ✅ aktif |
+| `calculator` | open | ✅ aktif |
+| `search_web_wikipedia` | open | ✅ aktif (Wikipedia API resmi) |
+| `orchestration_plan` | open | ✅ aktif |
+| `workspace_list` | open | ✅ aktif |
+| `workspace_read` | open | ✅ aktif |
+| `workspace_write` | restricted | ✅ aktif (butuh allow_restricted) |
+| `roadmap_list/next_items/mark_done/item_references` | open | ✅ aktif (4 tool) |
+| `web_fetch` | open | ✅ **aktif 2026-04-19** (httpx + BeautifulSoup, strip HTML → teks bersih) |
+| `code_sandbox` | open | ✅ **aktif 2026-04-19** (Python subprocess `-I -B`, timeout 10s, tempdir cwd, pattern block os.system/socket) |
+| `web_search` | open | ✅ **aktif 2026-04-19** (DuckDuckGo HTML + own parser, no vendor search API) |
+| `pdf_extract` | open | ✅ **aktif 2026-04-19** (pdfplumber own-stack, workspace path-traversal guard) |
+
+### Autonomous learning (backend-only, tidak di-trigger dari chat UI)
+- `learn_agent.py` — fetch→dedup→queue→index→auto-note. Sudah tested: arXiv 15, MusicBrainz 10, GitHub 15 (lihat notes 154-156).
+- 5 connectors: arXiv, Wikipedia, MusicBrainz, GitHub, Quran (semua own wrapper pakai `urllib.request`)
+- Endpoint admin: `/learn/status`, `/learn/run`, `/learn/process_queue`
+- `daily_growth.py` — 7-phase continual learning: SCAN→RISET→APPROVE→TRAIN→SHARE→REMEMBER→LOG
+- `initiative.py` — domain mastery mapping per persona, auto-trigger research untuk low-confidence answer
+- `curriculum_engine.py` — daily lesson rotator 11 domain
+- `brain_synthesizer.py` — knowledge graph + concept lexicon (IHOS, Sanad, Maqasid, dll.)
+
+### Social / Output
+- `channel_adapters.py` — WhatsApp, Telegram, generic webhooks
+- `threads_autopost.py`, `admin_threads.py` — Threads social agent (tested, live)
+- Endpoint `/threads/*` (40 endpoints)
+
+### Self-audit
+- `vision_tracker.py` — audit SIDIX vs visi 6 pillar (Epistemic Integrity, IHOS, Maqasid, Constitutional, Voyager, Hudhuri)
+
+---
+
+## ⚠️ SUDAH ADA KODE tapi BELUM DI-WIRE ke chat
+
+| Modul | Status | Aksi needed |
+|---|---|---|
+| `webfetch.py` | ✅ kode lengkap (httpx + BeautifulSoup → markdown) | Enable `web_fetch` di TOOL_REGISTRY (ganti `_tool_disabled` → real impl) |
+| `audio_capability.py` | ✅ registry TTS/ASR/voice-clone/music-gen | Butuh pasang dependency (whisper/librosa) + wire sebagai tool |
+| `brain_synthesizer.py` | ✅ knowledge graph | Wire sebagai tool `concept_graph` |
+| `learn_agent.py` | ✅ aktif backend-only | Tambah cron harian (blocker: .env token key name di server) |
+
+---
+
+## ❌ BELUM ADA (capability gap)
+
+| Capability | Kebutuhan | Pendekatan standing-alone |
+|---|---|---|
+| **Code execution** | Jalankan Python snippet user | Python subprocess + timeout + resource limit + allowlist import. 100% own infra. **P1 — quick win** |
+| **Image generation** | Buat gambar dari prompt | Self-host Stable Diffusion / FLUX.1 di GPU server. Butuh infra GPU. **P2 — heavy** |
+| **Vision / multimodal input** | Analisis gambar user upload | Self-host VLM (Qwen2.5-VL / InternVL). Butuh GPU. **P2 — heavy** |
+| **OCR / PDF analysis** | Ekstrak teks dari upload | `pdfplumber` + `pytesseract` (own infra, CPU). **P1** |
+| **Generic web search** | Search di web umum | Own fetcher + parser. Bisa scrape DuckDuckGo HTML (terbuka, tanpa API). **P1** (atau extend webfetch) |
+| **Audio input (ASR)** | User kirim suara | `whisper.cpp` self-host. **P2** |
+| **TTS output** | SIDIX bicara | `Piper` / `Coqui XTTS` self-host. **P2** |
+
+---
+
+## 🗺️ ROADMAP IMPLEMENTASI (per prioritas standing-alone)
+
+**Roadmap 2026 lengkap (4 stage × sprint 2 minggu):** `docs/SIDIX_ROADMAP_2026.md`
+- Baby (Q1–Q2): solidkan 3-layer, tutup gap no-GPU
+- Child (Q3): multimodal parity (image/vision/audio/skill)
+- Adolescent (Q4–Q1'27): self-evolving (SPIN + merging + self-reward)
+- Adult (Q2'27+): distributed hafidz (DiLoCo + BFT + IPFS)
+
+Foundation konsep: `brain/public/research_notes/161_*.md`.
+
+---
+
+**P1 quick wins (dipecah dari Baby sprint 1):**
+
+### P1 — Quick wins (bisa hari ini, tanpa GPU) — SEMUA SELESAI 2026-04-19
+1. ✅ **Enable `web_fetch`** — tool fetch URL → markdown untuk chat
+2. ✅ **Add `code_sandbox`** — Python subprocess dengan timeout 10s + no network + import allowlist
+3. ✅ **Add `pdf_extract`** — upload PDF → text via `pdfplumber`
+4. ✅ **Add `web_search`** — own wrapper DuckDuckGo HTML → list hasil (no API)
+
+### P2 — Need infra (minggu depan)
+5. **Self-host Whisper** untuk ASR (`whisper.cpp` CPU-only)
+6. **Self-host Piper** untuk TTS
+7. **GPU server** → self-host SDXL/FLUX + Qwen2.5-VL
+
+### P3 — Advanced
+8. **Self-evolving** via DiLoCo + model merging (note 41)
+9. **VLM fine-tune** dataset Nusantara (note 45-46)
+10. **Video diffusion** (note 118)
+
+---
+
+## 📂 FILE RELEVAN (untuk agent sesi berikut)
+
+**Harus baca dulu:**
+- `CLAUDE.md` — aturan permanen + UI LOCK
+- `docs/SIDIX_BIBLE.md` — konstitusi
+- `docs/SIDIX_CAPABILITY_MAP.md` — file ini
+- `docs/LIVING_LOG.md` tail 50
+
+**Kode kapabilitas:**
+- `apps/brain_qa/brain_qa/agent_tools.py` — TOOL_REGISTRY
+- `apps/brain_qa/brain_qa/agent_serve.py` — endpoint HTTP
+- `apps/brain_qa/brain_qa/webfetch.py` — fetch URL (belum wired)
+- `apps/brain_qa/brain_qa/connectors/` — 5 open data connectors
+- `apps/brain_qa/brain_qa/learn_agent.py` — autonomous learning
+- `apps/brain_qa/brain_qa/local_llm.py` — own inference
+
+**Frontend (LOCKED, jangan ubah struktur):**
+- `SIDIX_USER_UI/index.html`
+- `SIDIX_USER_UI/src/main.ts`
+
+---
+
+## 🚫 JANGAN LAKUKAN (anti-pattern)
+
+- ❌ Jangan bikin file audit baru — update file ini
+- ❌ Jangan tambah "Gabung Kontributor" di nav chat app.sidixlab.com (flow di landing sidixlab.com#contributor)
+- ❌ Jangan pakai `fetch(openai.com)` atau SDK vendor AI
+- ❌ Jangan ubah layout empty-state tanpa izin user (locked 2026-04-19)
+- ❌ Jangan `rsync dist/ ke /www/wwwroot/app.sidixlab.com/` (nginx proxy, bukan static)
+- ❌ Jangan skip update LIVING_LOG

--- a/docs/agent_tasks/reports/T1.2_report_cursor.md
+++ b/docs/agent_tasks/reports/T1.2_report_cursor.md
@@ -1,0 +1,46 @@
+# Report T1.2 — Sanad-Based Ranker (Cursor)
+
+**Branch:** `cursor/sprint-1/t1.2-sanad-ranker`  
+**Task file:** `docs/agent_tasks/SPRINT_1_CURSOR.md` (mirror: `determined-chaum-f21c81/docs/agent_tasks/SPRINT_1_CURSOR.md`)
+
+## Ringkasan
+
+Implementasi reranking hasil BM25 dengan faktor `sanad_tier` dari YAML frontmatter note, modul baru `sanad_ranking.py`, unit test, research note 164, update `docs/SIDIX_CAPABILITY_MAP.md`, append `docs/LIVING_LOG.md`.
+
+## File berubah (utama)
+
+| Path | Perubahan |
+|------|-----------|
+| `apps/brain_qa/brain_qa/sanad_ranking.py` | Baru: bobot tier, `normalize_sanad_tier`, `apply_sanad_weight`, `extract_sanad_tier_from_markdown` |
+| `apps/brain_qa/brain_qa/text.py` | `Chunk.sanad_tier` default `unknown` |
+| `apps/brain_qa/brain_qa/indexer.py` | Set `sanad_tier` per file ke setiap chunk |
+| `apps/brain_qa/brain_qa/query.py` | Rerank `BM25 * weight`, `Citation.sanad_tier`, `citation_meta["sanad_tier"]` |
+| `apps/brain_qa/brain_qa/hadith_validate.py` | Load chunk dengan normalisasi tier |
+| `apps/brain_qa/brain_qa/agent_tools.py` | `read_chunk` citations sertakan `sanad_tier` |
+| `apps/brain_qa/tests/test_sanad_ranker.py` | Baru: 4 test |
+| `apps/brain_qa/requirements.txt` | `pytest>=8.0.0` |
+| `brain/public/research_notes/` | Frontmatter pada 03, 41, 157, 161, 162; note 164 baru; salin 157/161/162 dari mirror jika belum ada |
+| `docs/SIDIX_CAPABILITY_MAP.md` | Baru (salin + baris sanad rerank) |
+| `docs/LIVING_LOG.md` | Append IMPL/TEST/DOC |
+
+## Hasil test
+
+```
+pytest tests/test_sanad_ranker.py -v
+```
+4 passed (primer vs peer_review, tie-break BM25, unknown default, frontmatter parse).
+
+## Verifikasi pasca-merge (operator)
+
+1. Rebuild index: `python -m brain_qa index` (dari env yang memakai manifest corpus).
+2. Smoke: `search_corpus` — cek urutan dan field `sanad_tier` di citation.
+
+## Blocker / edge case
+
+- Index lama tanpa field `sanad_tier` di JSONL: di-load sebagai `unknown` (normalisasi di `_load_chunks`).
+- Tanpa re-index setelah menambah frontmatter, tier tidak terbaca dari disk index.
+
+## Before/after (konseptual)
+
+- **Before:** Urutan murni skor BM25.
+- **After:** Skor efektif = BM25 × bobot tier; urutan mengikuti skor efektif, tie-break dengan BM25 mentah.


### PR DESCRIPTION
…1.2)

BM25 scores multiplied by editorial sanad_tier from YAML frontmatter; indexer propagates tier per chunk; citations expose sanad_tier. Tests, research note 164, capability map, LIVING_LOG.


Made-with: Cursor