### PR TITLE
Sprint 5: curator_agent, debate_ring, agency_kit, llm_judge, prompt_optimizer + 34 tools

### DIFF
--- a/apps/brain_qa/brain_qa/agency_kit.py
+++ b/apps/brain_qa/brain_qa/agency_kit.py
@@ -1,0 +1,400 @@
+"""
+agency_kit.py — SIDIX Agency Kit 1-Click (Sprint 5, Killer Offer #4)
+
+Input: business_name + niche + target_audience + budget
+Output (1 klik, ~10-30 detik):
+  ✅ Brand Kit (archetype + voice + palette hint + tagline)
+  ✅ 10 Caption IG (3 AIDA, 3 PAS, 2 FAB, 2 bonus)
+  ✅ 30-day Content Plan (21 slots)
+  ✅ Campaign Strategy (AARRR 5 stages)
+  ✅ 3 Ad Variants (FB/Google/TikTok)
+  ✅ 3 Thumbnail Specs
+  ✅ Muhasabah quality gate per layer
+  ✅ Total CQF composite score
+
+Pipeline DAG:
+  brand_builder
+       ↓
+  content_planner + copywriter×5 (parallel-ish via loop)
+       ↓
+  campaign_strategist
+       ↓
+  ads_generator × 3 platforms
+       ↓
+  thumbnail_generator × 3
+       ↓
+  muhasabah_loop (gate final bundle)
+       ↓
+  return AgencyKitResult
+
+Dibuat own-stack: tidak ada vendor API. Setiap layer pakai modul Sprint 4.
+"""
+
+from __future__ import annotations
+
+import time
+import logging
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+logger = logging.getLogger("sidix.agency_kit")
+
+
+# ── Result model ──────────────────────────────────────────────────────────────
+@dataclass
+class AgencyKitResult:
+    ok: bool
+    business_name: str
+    niche: str
+    target_audience: str
+
+    # Layer 1 — Brand
+    brand_kit: dict = field(default_factory=dict)
+
+    # Layer 2 — Content
+    captions: list[dict] = field(default_factory=list)       # 10 caption
+    content_plan: list[dict] = field(default_factory=list)   # 30-day plan
+
+    # Layer 3 — Campaign
+    campaign: dict = field(default_factory=dict)
+
+    # Layer 4 — Ads
+    ads: list[dict] = field(default_factory=list)            # 3 platform
+
+    # Layer 5 — Thumbnails
+    thumbnails: list[dict] = field(default_factory=list)     # 3 specs
+
+    # Meta
+    muhasabah: dict = field(default_factory=dict)
+    cqf_composite: float = 0.0
+    elapsed_s: float = 0.0
+    warnings: list[str] = field(default_factory=list)
+    error: str = ""
+
+
+# ── Helper: safe module calls ─────────────────────────────────────────────────
+def _safe(fn, *args, **kwargs) -> tuple[Any, str]:
+    """Call fn, return (result, error_str). Error tidak crash pipeline."""
+    try:
+        return fn(*args, **kwargs), ""
+    except Exception as exc:
+        logger.warning("agency_kit safe-call error: %s — %s", fn.__name__, exc)
+        return None, str(exc)
+
+
+# ── Pipeline layers ───────────────────────────────────────────────────────────
+def _layer_brand(business_name: str, niche: str, target_audience: str) -> tuple[dict, str]:
+    from .brand_builder import generate_brand_kit
+    r, err = _safe(
+        generate_brand_kit,
+        business_name=business_name,
+        niche=niche,
+        target_audience=target_audience,
+    )
+    if r and r.get("ok"):
+        return r, ""
+    return {}, err or "brand_kit failed"
+
+
+def _layer_captions(
+    business_name: str, niche: str, target_audience: str, brand_voice: str
+) -> list[dict]:
+    from .copywriter import generate_copy
+
+    caption_configs = [
+        {"formula": "AIDA", "tone": "friendly"},
+        {"formula": "AIDA", "tone": "professional"},
+        {"formula": "AIDA", "tone": "bold"},
+        {"formula": "PAS",  "tone": "empathetic"},
+        {"formula": "PAS",  "tone": "bold"},
+        {"formula": "PAS",  "tone": "friendly"},
+        {"formula": "FAB",  "tone": "professional"},
+        {"formula": "FAB",  "tone": "friendly"},
+        {"formula": "AIDA", "tone": "playful"},
+        {"formula": "PAS",  "tone": "inspirational"},
+    ]
+
+    captions: list[dict] = []
+    for cfg in caption_configs:
+        topic = f"{business_name} — {niche} untuk {target_audience}"
+        r, err = _safe(
+            generate_copy,
+            topic=topic,
+            channel="instagram",
+            formula=cfg["formula"],
+            audience=target_audience,
+            tone=cfg["tone"],
+            variant_count=1,
+        )
+        if r and r.get("ok"):
+            captions.append({
+                "formula": cfg["formula"],
+                "tone": cfg["tone"],
+                "text": r.get("best_text", ""),
+                "score": r.get("score_total", 0),
+            })
+        else:
+            logger.warning("caption skip: formula=%s tone=%s err=%s", cfg["formula"], cfg["tone"], err)
+
+    return captions
+
+
+def _layer_content_plan(niche: str, target_audience: str) -> list[dict]:
+    from .content_planner import generate_content_plan
+    r, err = _safe(
+        generate_content_plan,
+        niche=niche,
+        target_audience=target_audience,
+        duration_days=30,
+        posts_per_week=5,
+    )
+    if r and r.get("ok"):
+        return r.get("plan", [])
+    return []
+
+
+def _layer_campaign(
+    business_name: str, niche: str, target_audience: str, budget_idr: int
+) -> dict:
+    from .campaign_strategist import plan_campaign
+    r, err = _safe(
+        plan_campaign,
+        product=f"{business_name} ({niche})",
+        audience=target_audience,
+        goal="conversion",
+        budget_idr=budget_idr,
+        duration_days=30,
+    )
+    if r and r.get("ok"):
+        return r
+    return {}
+
+
+def _layer_ads(business_name: str, niche: str, target_audience: str) -> list[dict]:
+    from .ads_generator import generate_ads
+
+    platforms = ["facebook", "google", "tiktok"]
+    ads: list[dict] = []
+    for platform in platforms:
+        r, err = _safe(
+            generate_ads,
+            product=f"{business_name} — {niche}",
+            audience=target_audience,
+            platform=platform,
+            objective="conversion",
+            n_variants=2,
+        )
+        if r and r.get("ok"):
+            ads.append({
+                "platform": platform,
+                "best_variant": r.get("best_variant", {}),
+                "all_variants": r.get("variants", []),
+                "cqf": r.get("cqf", {}).get("total", 0),
+            })
+        else:
+            ads.append({"platform": platform, "error": err})
+
+    return ads
+
+
+def _layer_thumbnails(business_name: str, niche: str) -> list[dict]:
+    from .thumbnail_generator import generate_thumbnail
+
+    specs = [
+        {"title": f"{business_name} — Tips {niche} Terbaik",     "platform": "youtube", "style": "bold"},
+        {"title": f"Rahasia Sukses {niche} untuk Pemula",          "platform": "instagram", "style": "clean"},
+        {"title": f"{business_name} × Cara Kerja yang Lebih Baik", "platform": "youtube", "style": "minimal"},
+    ]
+
+    thumbnails: list[dict] = []
+    for spec in specs:
+        r, err = _safe(
+            generate_thumbnail,
+            title=spec["title"],
+            platform=spec["platform"],
+            style=spec["style"],
+            brand_hint=business_name,
+        )
+        if r and r.get("ok"):
+            thumbnails.append({
+                "platform": spec["platform"],
+                "title": spec["title"],
+                "layout": r.get("layout"),
+                "image_prompt": r.get("image_prompt", ""),
+                "cqf": r.get("cqf", {}).get("total", 0),
+            })
+        else:
+            thumbnails.append({"platform": spec["platform"], "title": spec["title"], "error": err})
+
+    return thumbnails
+
+
+def _layer_muhasabah(bundle_summary: str) -> dict:
+    from .muhasabah_loop import run_muhasabah_loop
+    r, err = _safe(
+        run_muhasabah_loop,
+        brief=bundle_summary,
+        domain="marketing",
+        generate_fn=lambda b: b,
+        max_rounds=2,
+        min_score=7.0,
+    )
+    if r and r.get("ok"):
+        return r
+    return {"ok": False, "error": err, "final_score": 0.0}
+
+
+def _calc_composite_cqf(
+    brand_kit: dict,
+    captions: list[dict],
+    campaign: dict,
+    ads: list[dict],
+    thumbnails: list[dict],
+) -> float:
+    scores: list[float] = []
+    if brand_kit.get("cqf", {}).get("total"):
+        scores.append(float(brand_kit["cqf"]["total"]))
+    for c in captions:
+        if c.get("score"):
+            scores.append(float(c["score"]))
+    if campaign.get("cqf", {}).get("total"):
+        scores.append(float(campaign["cqf"]["total"]))
+    for a in ads:
+        if a.get("cqf"):
+            scores.append(float(a["cqf"]))
+    for t in thumbnails:
+        if t.get("cqf"):
+            scores.append(float(t["cqf"]))
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 2)
+
+
+def _parse_budget(budget_str: str) -> int:
+    """Parse '2jt' / '500rb' / '1500000' → int rupiah."""
+    s = str(budget_str).lower().replace(" ", "").replace("rp", "").replace(",", "").replace(".", "")
+    try:
+        if "jt" in s or "juta" in s:
+            n = float(s.replace("jt", "").replace("juta", ""))
+            return int(n * 1_000_000)
+        if "rb" in s or "ribu" in s:
+            n = float(s.replace("rb", "").replace("ribu", ""))
+            return int(n * 1_000)
+        return max(500_000, int(s))
+    except ValueError:
+        return 1_500_000   # default 1.5 juta
+
+
+# ── Main entry point ──────────────────────────────────────────────────────────
+def build_agency_kit(
+    *,
+    business_name: str,
+    niche: str,
+    target_audience: str,
+    budget: str = "1.5jt",
+    skip_thumbnails: bool = False,
+    skip_ads: bool = False,
+) -> dict:
+    """
+    Bangun Agency Kit lengkap dalam 1 panggilan.
+
+    Returns dict (serializable) dengan semua layer.
+    """
+    start = time.time()
+    warnings: list[str] = []
+
+    bn = (business_name or "").strip()
+    ni = (niche or "").strip()
+    ta = (target_audience or "").strip()
+
+    if not bn:
+        return {"ok": False, "error": "business_name wajib diisi"}
+    if not ni:
+        return {"ok": False, "error": "niche wajib diisi"}
+    if not ta:
+        ta = "audiens Indonesia umum"
+
+    budget_idr = _parse_budget(budget)
+    logger.info("agency_kit: mulai untuk '%s' niche='%s' audience='%s'", bn, ni, ta)
+
+    # ── Layer 1: Brand ────────────────────────────────────────────────────────
+    logger.info("agency_kit [1/6] brand_builder")
+    brand_kit, err = _layer_brand(bn, ni, ta)
+    if err:
+        warnings.append(f"brand_kit: {err}")
+    brand_voice = brand_kit.get("voice_tone", f"{bn} yang friendly dan terpercaya")
+
+    # ── Layer 2a: Captions ────────────────────────────────────────────────────
+    logger.info("agency_kit [2/6] copywriter × 10")
+    captions = _layer_captions(bn, ni, ta, brand_voice)
+    if len(captions) < 5:
+        warnings.append(f"Hanya {len(captions)} caption berhasil dibuat (target 10)")
+
+    # ── Layer 2b: Content Plan ────────────────────────────────────────────────
+    logger.info("agency_kit [3/6] content_planner")
+    content_plan = _layer_content_plan(ni, ta)
+    if not content_plan:
+        warnings.append("content_plan kosong, cek content_planner module")
+
+    # ── Layer 3: Campaign ─────────────────────────────────────────────────────
+    logger.info("agency_kit [4/6] campaign_strategist")
+    campaign = _layer_campaign(bn, ni, ta, budget_idr)
+    if not campaign:
+        warnings.append("campaign gagal, cek campaign_strategist module")
+
+    # ── Layer 4: Ads ──────────────────────────────────────────────────────────
+    ads: list[dict] = []
+    if not skip_ads:
+        logger.info("agency_kit [5/6] ads_generator × 3 platforms")
+        ads = _layer_ads(bn, ni, ta)
+
+    # ── Layer 5: Thumbnails ───────────────────────────────────────────────────
+    thumbnails: list[dict] = []
+    if not skip_thumbnails:
+        logger.info("agency_kit [6/6] thumbnail_generator × 3")
+        thumbnails = _layer_thumbnails(bn, ni)
+
+    # ── Muhasabah: quality gate ───────────────────────────────────────────────
+    bundle_summary = (
+        f"Agency Kit untuk {bn} ({ni}), target {ta}, budget Rp{budget_idr:,}. "
+        f"Brand: {brand_voice}. "
+        f"Captions: {len(captions)}, Plan: {len(content_plan)} slots, "
+        f"Campaign stages: {len(campaign.get('funnel', []))}."
+    )
+    muhasabah = _layer_muhasabah(bundle_summary)
+
+    cqf_composite = _calc_composite_cqf(brand_kit, captions, campaign, ads, thumbnails)
+    elapsed = round(time.time() - start, 2)
+
+    logger.info(
+        "agency_kit selesai: cqf=%.2f elapsed=%.1fs warnings=%d",
+        cqf_composite, elapsed, len(warnings),
+    )
+
+    return {
+        "ok": True,
+        "business_name": bn,
+        "niche": ni,
+        "target_audience": ta,
+        "budget_idr": budget_idr,
+
+        # Layers
+        "brand_kit": brand_kit,
+        "captions": captions,
+        "caption_count": len(captions),
+        "content_plan": content_plan,
+        "content_plan_slots": len(content_plan),
+        "campaign": campaign,
+        "ads": ads,
+        "thumbnails": thumbnails,
+
+        # Quality
+        "muhasabah": muhasabah,
+        "cqf_composite": cqf_composite,
+        "cqf_tier": "premium" if cqf_composite >= 8.5 else "delivery" if cqf_composite >= 7.0 else "needs_work",
+
+        # Meta
+        "elapsed_s": elapsed,
+        "warnings": warnings,
+        "summary": bundle_summary,
+    }

--- a/apps/brain_qa/brain_qa/agent_serve.py
+++ b/apps/brain_qa/brain_qa/agent_serve.py
@@ -3128,6 +3128,46 @@ h1{{color:#0af}}p{{color:#aaa}}a{{color:#0af}}</style></head>
         except Exception as e:
             return {"ok": False, "error": str(e)}
 
+    # ── Sprint 5: Creative Agency Kit endpoint ───────────────────────────────
+    @app.post("/creative/agency_kit", tags=["Creative"])
+    def creative_agency_kit(body: dict[str, Any] = {}):
+        """
+        Build Agency Kit lengkap dalam 1 panggilan.
+
+        Body:
+          business_name   (str, wajib) — nama bisnis/brand
+          niche           (str, wajib) — bidang usaha (kuliner, fashion, jasa, dll)
+          target_audience (str)        — deskripsi audiens target
+          budget          (str)        — budget iklan (contoh: '1.5jt', '500rb', default '1.5jt')
+
+        Returns:
+          {ok, brand_kit, captions, content_plan, campaign, ads, thumbnails,
+           cqf_composite, cqf_tier, elapsed_s, warnings}
+        """
+        try:
+            from .agency_kit import build_agency_kit
+            business_name = str((body or {}).get("business_name", "")).strip()
+            niche = str((body or {}).get("niche", "")).strip()
+            target_audience = str((body or {}).get("target_audience", "")).strip()
+            budget = str((body or {}).get("budget", "1.5jt")).strip() or "1.5jt"
+
+            if not business_name:
+                raise HTTPException(status_code=400, detail="business_name wajib diisi")
+            if not niche:
+                raise HTTPException(status_code=400, detail="niche wajib diisi")
+
+            result = build_agency_kit(
+                business_name=business_name,
+                niche=niche,
+                target_audience=target_audience or "audiens Indonesia umum",
+                budget=budget,
+            )
+            return result
+        except HTTPException:
+            raise
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
     # ── Concept graph endpoint (Sprint 1 T1.4) ───────────────────────────────
     @app.get("/concept_graph/query")
     def concept_graph_query(request: Request, concept: str = "", depth: int = 1, max_related: int = 5):

--- a/apps/brain_qa/brain_qa/agent_tools.py
+++ b/apps/brain_qa/brain_qa/agent_tools.py
@@ -1250,6 +1250,47 @@ def _tool_llm_judge(args: dict) -> ToolResult:
     )
 
 
+def _tool_prompt_optimizer(args: dict) -> ToolResult:
+    """Optimalkan prompt template agent berdasarkan accepted outputs (L1 Self-Evolution)."""
+    agent = str(args.get("agent", "")).strip()
+    domain = str(args.get("domain", "content")).strip() or "content"
+    force = bool(args.get("force", False))
+    dry_run = bool(args.get("dry_run", False))
+
+    if not agent:
+        return ToolResult(success=False, output="", error="agent wajib diisi (copywriter/brand_builder/campaign_strategist/...)")
+
+    try:
+        from .prompt_optimizer import optimize_prompt
+        result = optimize_prompt(agent=agent, domain=domain, force=force, dry_run=dry_run)
+    except Exception as e:
+        return ToolResult(success=False, output="", error=f"prompt_optimizer gagal: {e}")
+
+    lines = [
+        "# Prompt Optimizer — Hasil",
+        f"- Agent: {result.agent}",
+        f"- Version: v{result.version}",
+        f"- Baseline Score: {result.baseline_score:.2f}",
+        f"- Optimized Score: {result.optimized_score:.2f}",
+        f"- Improvement: {result.improvement:+.2f}",
+        f"- Accepted: {'✅ Ya' if result.accepted else '❌ Tidak (rollback ke versi lama)'}",
+        f"- Demos Used: {result.demos_used}",
+        f"- Status: {result.notes}",
+        f"- Elapsed: {result.elapsed_s}s",
+    ]
+    return ToolResult(
+        success=result.ok,
+        output="\n".join(lines),
+        citations=[{
+            "type": "prompt_optimizer",
+            "agent": result.agent,
+            "version": result.version,
+            "improvement": result.improvement,
+            "accepted": result.accepted,
+        }],
+    )
+
+
 # ── web_fetch — own stack, fetch HTML publik, strip ke markdown/plain ─────────
 _WEB_FETCH_MAX_BYTES = 800_000  # ~800 KB HTML mentah
 _WEB_FETCH_TEXT_LIMIT = 6000    # karakter teks yang dikembalikan ke agent
@@ -2216,6 +2257,20 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         params=["content", "brief", "domain"],
         permission="open",
         fn=_tool_llm_judge,
+    ),
+    "prompt_optimizer": ToolSpec(
+        name="prompt_optimizer",
+        description=(
+            "Optimalkan prompt template agent secara otomatis berdasarkan accepted outputs "
+            "(Self-Evolution Level 1). Analisis pola output terbaik → ekstrak few-shot demos "
+            "→ inject ke template → evaluasi improvement. "
+            "Parameter: agent (str: copywriter/brand_builder/campaign_strategist/content_planner/ads_generator), "
+            "domain (str: content|brand|campaign, default content), "
+            "force (bool, override min-sample check), dry_run (bool, simulasi tanpa simpan)."
+        ),
+        params=["agent", "domain", "force", "dry_run"],
+        permission="restricted",
+        fn=_tool_prompt_optimizer,
     ),
 }
 

--- a/apps/brain_qa/brain_qa/agent_tools.py
+++ b/apps/brain_qa/brain_qa/agent_tools.py
@@ -1044,6 +1044,212 @@ def _tool_disabled(args: dict) -> ToolResult:
     return ToolResult(success=False, output="", error="Tool ini disabled oleh permission gate")
 
 
+# ── Sprint 5 Tools ─────────────────────────────────────────────────────────────
+
+def _tool_curator_run(args: dict) -> ToolResult:
+    """Jalankan self-train curation pipeline dari corpus."""
+    min_score = float(args.get("min_score", 0.45))
+    dry_run = bool(args.get("dry_run", False))
+
+    try:
+        from .curator_agent import run_curation
+        result = run_curation(min_score=min_score, dry_run=dry_run)
+    except Exception as e:
+        return ToolResult(success=False, output="", error=f"curator_run gagal: {e}")
+
+    if not result.get("ok"):
+        return ToolResult(success=False, output="", error=str(result.get("error", "unknown")))
+
+    lines = [
+        "# Curator Agent — Self-Train Curation",
+        f"- Scanned: {result.get('scanned')} dokumen",
+        f"- Scored (pass threshold): {result.get('scored')}",
+        f"- Exported pairs: {result.get('exported')}",
+        f"- Output file: {result.get('output_file') or '(dry-run, tidak disimpan)'}",
+        f"- Elapsed: {result.get('elapsed_s')}s",
+    ]
+    warnings = result.get("warnings", [])
+    if warnings:
+        lines.append("\n## Warnings")
+        for w in warnings[:5]:
+            lines.append(f"- {w}")
+
+    return ToolResult(
+        success=True,
+        output="\n".join(lines),
+        citations=[{
+            "type": "curator_run",
+            "exported": result.get("exported"),
+            "dry_run": dry_run,
+        }],
+    )
+
+
+def _tool_debate_ring(args: dict) -> ToolResult:
+    """Jalankan multi-agent debate Creator ↔ Critic."""
+    pair_type = str(args.get("pair_type", "copy_vs_strategy")).strip()
+    content = str(args.get("content", "")).strip()
+    context = str(args.get("context", "")).strip()
+
+    if not content:
+        return ToolResult(success=False, output="", error="content wajib diisi")
+
+    try:
+        from .debate_ring import (
+            debate_copy_vs_strategy,
+            debate_brand_vs_design,
+            debate_hook_vs_audience,
+            run_debate_as_dict,
+        )
+
+        pair_map = {
+            "copy_vs_strategy": debate_copy_vs_strategy,
+            "brand_vs_design": debate_brand_vs_design,
+            "hook_vs_audience": debate_hook_vs_audience,
+        }
+
+        fn = pair_map.get(pair_type)
+        if fn is None:
+            return ToolResult(
+                success=False, output="",
+                error=f"pair_type '{pair_type}' tidak valid. Pilih: {list(pair_map.keys())}",
+            )
+
+        result = fn(content, context)
+        d = run_debate_as_dict(result)
+
+    except Exception as e:
+        return ToolResult(success=False, output="", error=f"debate_ring gagal: {e}")
+
+    lines = [
+        f"# Debate Ring — {d['pair_id']}",
+        f"- Konsensus: {'Ya' if d['consensus'] else 'Tidak (max round tercapai)'}",
+        f"- Rounds: {d['rounds_taken']}",
+        f"- Final CQF: {d['final_cqf']}",
+        f"- Elapsed: {d['elapsed_s']}s",
+        "",
+        "## Final Output",
+        d["final_prototype"],
+    ]
+
+    return ToolResult(
+        success=True,
+        output="\n".join(lines),
+        citations=[{
+            "type": "debate_ring",
+            "pair_id": d["pair_id"],
+            "consensus": d["consensus"],
+            "final_cqf": d["final_cqf"],
+        }],
+    )
+
+
+def _tool_agency_kit(args: dict) -> ToolResult:
+    """Build Agency Kit lengkap dalam 1 panggilan."""
+    business_name = str(args.get("business_name", "")).strip()
+    niche = str(args.get("niche", "")).strip()
+    target_audience = str(args.get("target_audience", "")).strip()
+    budget = str(args.get("budget", "1.5jt")).strip() or "1.5jt"
+
+    if not business_name:
+        return ToolResult(success=False, output="", error="business_name wajib diisi")
+    if not niche:
+        return ToolResult(success=False, output="", error="niche wajib diisi")
+
+    try:
+        from .agency_kit import build_agency_kit
+        result = build_agency_kit(
+            business_name=business_name,
+            niche=niche,
+            target_audience=target_audience or "audiens Indonesia umum",
+            budget=budget,
+        )
+    except Exception as e:
+        return ToolResult(success=False, output="", error=f"agency_kit gagal: {e}")
+
+    if not result.get("ok"):
+        return ToolResult(success=False, output="", error=str(result.get("error", "unknown")))
+
+    lines = [
+        "# Agency Kit — 1-Click Brand Package",
+        f"- Bisnis: {result.get('business_name')}",
+        f"- Niche: {result.get('niche')}",
+        f"- Target: {result.get('target_audience')}",
+        f"- Budget: Rp {result.get('budget_idr', 0):,}".replace(",", "."),
+        f"- CQF Composite: {result.get('cqf_composite')} ({result.get('cqf_tier')})",
+        f"- Captions: {result.get('caption_count')} caption",
+        f"- Content Plan: {result.get('content_plan_slots')} slots",
+        f"- Elapsed: {result.get('elapsed_s')}s",
+        "",
+        "## Summary",
+        result.get("summary", ""),
+    ]
+    warnings = result.get("warnings", [])
+    if warnings:
+        lines.append("\n## Warnings")
+        for w in warnings[:5]:
+            lines.append(f"- {w}")
+
+    return ToolResult(
+        success=True,
+        output="\n".join(lines),
+        citations=[{
+            "type": "agency_kit",
+            "business_name": business_name,
+            "cqf_composite": result.get("cqf_composite"),
+            "caption_count": result.get("caption_count"),
+        }],
+    )
+
+
+def _tool_llm_judge(args: dict) -> ToolResult:
+    """Evaluasi kualitas konten menggunakan LLM-as-Judge."""
+    content = str(args.get("content", "")).strip()
+    brief = str(args.get("brief", "")).strip()
+    domain = str(args.get("domain", "content")).strip() or "content"
+
+    if not content:
+        return ToolResult(success=False, output="", error="content wajib diisi")
+
+    try:
+        from .llm_judge import judge_content
+        result = judge_content(content=content, brief=brief, domain=domain)
+    except Exception as e:
+        return ToolResult(success=False, output="", error=f"llm_judge gagal: {e}")
+
+    if not result.get("ok"):
+        return ToolResult(success=False, output="", error=str(result.get("error", "unknown")))
+
+    scores = result.get("scores", {})
+    lines = [
+        "# LLM Judge — Content Evaluation",
+        f"- Domain: {result.get('domain')}",
+        f"- Mode: {result.get('mode')} (llm / heuristic)",
+        f"- Total Score: {result.get('total')} → Tier: {result.get('tier')}",
+        f"- Elapsed: {result.get('elapsed_s')}s",
+        "",
+        "## Scores per Criterion",
+    ]
+    for criterion, score in scores.items():
+        lines.append(f"- {criterion}: {score:.1f}/10")
+
+    if result.get("rationale"):
+        lines.extend(["", "## Rationale", result["rationale"]])
+    if result.get("recommendation"):
+        lines.extend(["", "## Recommendation", result["recommendation"]])
+
+    return ToolResult(
+        success=True,
+        output="\n".join(lines),
+        citations=[{
+            "type": "llm_judge",
+            "domain": result.get("domain"),
+            "total": result.get("total"),
+            "tier": result.get("tier"),
+        }],
+    )
+
+
 # ── web_fetch — own stack, fetch HTML publik, strip ke markdown/plain ─────────
 _WEB_FETCH_MAX_BYTES = 800_000  # ~800 KB HTML mentah
 _WEB_FETCH_TEXT_LIMIT = 6000    # karakter teks yang dikembalikan ke agent
@@ -1963,6 +2169,53 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         params=["target"],
         permission="open",
         fn=_tool_self_inspect,
+    ),
+    # ── Sprint 5 Tools ─────────────────────────────────────────────────────────
+    "curator_run": ToolSpec(
+        name="curator_run",
+        description=(
+            "Jalankan curation pipeline untuk export JSONL training pairs dari corpus. "
+            "Scoring: relevance×sanad×maqashid×dedupe. "
+            "Params: min_score (float, default 0.45), dry_run (bool, default false)."
+        ),
+        params=["min_score", "dry_run"],
+        permission="open",
+        fn=_tool_curator_run,
+    ),
+    "debate_ring": ToolSpec(
+        name="debate_ring",
+        description=(
+            "Jalankan multi-agent debate antara Creator dan Critic untuk memperbaiki konten. "
+            "Pair tersedia: copy_vs_strategy, brand_vs_design, hook_vs_audience. "
+            "Params: pair_type (str), content (str, wajib), context (str opsional)."
+        ),
+        params=["pair_type", "content", "context"],
+        permission="open",
+        fn=_tool_debate_ring,
+    ),
+    "agency_kit": ToolSpec(
+        name="agency_kit",
+        description=(
+            "Build Agency Kit lengkap dalam 1 panggilan: brand kit + 10 captions + "
+            "30-day plan + campaign + ads + thumbnails. "
+            "Params: business_name (str, wajib), niche (str, wajib), "
+            "target_audience (str, opsional), budget (str opsional, default '1.5jt')."
+        ),
+        params=["business_name", "niche", "target_audience", "budget"],
+        permission="open",
+        fn=_tool_agency_kit,
+    ),
+    "llm_judge": ToolSpec(
+        name="llm_judge",
+        description=(
+            "Evaluasi kualitas konten menggunakan LLM-as-Judge. Lebih eksplisit dan "
+            "dapat-diaudit daripada CQF heuristic saja. "
+            "Params: content (str, wajib), brief (str opsional), "
+            "domain (str: content|brand|campaign|design, default 'content')."
+        ),
+        params=["content", "brief", "domain"],
+        permission="open",
+        fn=_tool_llm_judge,
     ),
 }
 

--- a/apps/brain_qa/brain_qa/curator_agent.py
+++ b/apps/brain_qa/brain_qa/curator_agent.py
@@ -1,0 +1,331 @@
+"""
+curator_agent.py — SIDIX Self-Train Fase 1
+
+Fungsi: kurasikan konten corpus → scoring → export JSONL training pairs.
+
+Pipeline:
+  corpus docs (research_notes + web_clips + praxis)
+    → score tiap dokumen: relevance × sanad_tier × maqashid × dedupe
+    → filter score ≥ threshold
+    → konversi ke training pair (ChatML format Alpaca)
+    → simpan ke .data/training_curated/YYYY-MM-DD.jsonl
+
+Scoring formula (0.0–1.0):
+  relevance     40%  — keyword density + topic coverage
+  sanad_tier    25%  — sumber terpercaya? (FACT/OPINION/SPEC marker)
+  maqashid      20%  — selaras 5 maqashid al-syariah?
+  dedupe        15%  — belum pernah di-export (content-hash)
+
+Cron target: weekly Senin 03:00 UTC.
+Min pairs/run: 100. Jika kurang → log WARNING, jangan fail.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger("sidix.curator")
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+_BASE = Path(__file__).parent
+_WORKSPACE = _BASE.parent.parent.parent          # repo root
+_CORPUS_DIRS = [
+    _WORKSPACE / "brain" / "public" / "research_notes",
+    _WORKSPACE / "brain" / "public" / "praxis" / "lessons",
+    _WORKSPACE / "brain" / "public" / "sources" / "audio_ai",
+]
+_OUT_DIR = _BASE.parent / ".data" / "training_curated"
+_SEEN_FILE = _BASE.parent / ".data" / "curator_seen_hashes.json"
+_STATS_FILE = _BASE.parent / ".data" / "curator_stats.json"
+
+# ── Scoring config ─────────────────────────────────────────────────────────────
+MIN_SCORE = 0.45          # terendah masuk export
+MIN_PAIRS_TARGET = 100    # target per run (warning jika kurang)
+MAX_PAIRS_PER_RUN = 600   # cap supaya file tidak membengkak
+
+MAQASHID_KEYWORDS = {
+    "din":   ["iman", "ibadah", "quran", "hadith", "fiqih", "tauhid", "sunnah", "ibadat"],
+    "nafs":  ["kesehatan", "keselamatan", "keamanan", "jiwa", "mental", "psikologi"],
+    "aql":   ["ilmu", "belajar", "logika", "riset", "penelitian", "analisis", "pengetahuan"],
+    "nasl":  ["keluarga", "anak", "pendidikan", "generasi", "masyarakat", "sosial"],
+    "mal":   ["ekonomi", "bisnis", "kerja", "produktivitas", "keuangan", "usaha"],
+}
+
+SANAD_MARKERS = {
+    "high":   ["[FACT]", "[fact]", "mutawatir", "sahih", "terkonfirmasi", "source:", "referensi:"],
+    "medium": ["[OPINION]", "[opinion]", "menurut", "kemungkinan", "diduga", "analisis"],
+    "low":    ["[SPECULATION]", "[speculation]", "[UNKNOWN]", "mungkin", "belum pasti"],
+}
+
+RELEVANCE_BOOST_WORDS = [
+    "sidix", "agent", "llm", "rag", "lora", "qwen", "python", "fastapi",
+    "tool", "corpus", "training", "inference", "deployment", "model",
+    "creative", "copywriter", "brand", "campaign", "content",
+    "ihos", "sanad", "maqashid", "epistemologi", "islam",
+]
+
+
+# ── Data models ────────────────────────────────────────────────────────────────
+@dataclass
+class ScoredDoc:
+    path: str
+    content_hash: str
+    score: float
+    relevance: float
+    sanad: float
+    maqashid: float
+    dedupe: float
+    word_count: int
+    title: str
+
+
+@dataclass
+class TrainingPair:
+    instruction: str
+    input: str
+    output: str
+    source: str
+    score: float
+    timestamp: str
+
+
+# ── Scoring helpers ────────────────────────────────────────────────────────────
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()[:24]
+
+
+def _score_relevance(text: str, lower: str) -> float:
+    hit = sum(1 for w in RELEVANCE_BOOST_WORDS if w in lower)
+    word_count = max(1, len(text.split()))
+    density = hit / (word_count / 100)          # hits per 100 words
+    length_bonus = min(0.2, word_count / 5000)   # reward panjang, cap 0.2
+    raw = min(1.0, density * 0.15 + length_bonus)
+    return round(raw, 4)
+
+
+def _score_sanad(lower: str) -> float:
+    for m in SANAD_MARKERS["high"]:
+        if m.lower() in lower:
+            return 0.90
+    for m in SANAD_MARKERS["medium"]:
+        if m.lower() in lower:
+            return 0.65
+    for m in SANAD_MARKERS["low"]:
+        if m.lower() in lower:
+            return 0.35
+    return 0.50   # default netral
+
+
+def _score_maqashid(lower: str) -> float:
+    axes_hit = 0
+    for keywords in MAQASHID_KEYWORDS.values():
+        if any(k in lower for k in keywords):
+            axes_hit += 1
+    return round(min(1.0, axes_hit * 0.22), 4)   # 5 axis × 0.22 ≈ 1.0
+
+
+def _score_dedupe(content_hash: str, seen: set[str]) -> float:
+    return 0.0 if content_hash in seen else 1.0
+
+
+def _composite_score(rel: float, sanad: float, maq: float, dedup: float) -> float:
+    return round(rel * 0.40 + sanad * 0.25 + maq * 0.20 + dedup * 0.15, 4)
+
+
+# ── Doc scanner ───────────────────────────────────────────────────────────────
+def _iter_corpus_docs() -> Iterator[tuple[Path, str]]:
+    """Yield (path, content) untuk setiap .md/.txt di corpus dirs."""
+    for corpus_dir in _CORPUS_DIRS:
+        if not corpus_dir.exists():
+            continue
+        for p in sorted(corpus_dir.rglob("*.md")) + sorted(corpus_dir.rglob("*.txt")):
+            try:
+                text = p.read_text(encoding="utf-8", errors="ignore")
+                if len(text.strip()) > 100:
+                    yield p, text
+            except Exception as exc:
+                logger.warning("skip %s: %s", p, exc)
+
+
+def _extract_title(text: str, path: Path) -> str:
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("# "):
+            return line[2:].strip()[:100]
+    return path.stem.replace("_", " ")[:100]
+
+
+# ── Training pair builder ─────────────────────────────────────────────────────
+_PAIR_TEMPLATES = [
+    ("Apa itu {title}?", "Jelaskan secara ringkas."),
+    ("Bagaimana cara mengimplementasikan {title}?", "Berikan langkah-langkah praktis."),
+    ("Apa manfaat dari {title} untuk pengembangan AI?", "Berikan analisis singkat."),
+    ("Apa perbedaan {title} dengan pendekatan konvensional?", "Bandingkan secara ringkas."),
+    ("Jelaskan konsep kunci dari {title}.", ""),
+]
+
+
+def _build_training_pairs(doc: ScoredDoc, text: str) -> list[TrainingPair]:
+    """Buat 1–2 training pair dari satu dokumen."""
+    title = doc.title
+    # ambil 800 karakter pertama sebagai konteks
+    context = text[:800].strip()
+    # bersihkan heading markdown
+    context = re.sub(r"^#{1,6}\s+", "", context, flags=re.MULTILINE)
+    context = re.sub(r"\*\*(.+?)\*\*", r"\1", context)
+
+    pairs: list[TrainingPair] = []
+    ts = datetime.now(timezone.utc).isoformat()
+
+    # Pair 1: definisi / penjelasan
+    q = f"Apa itu {title}?"
+    pairs.append(TrainingPair(
+        instruction=q,
+        input="",
+        output=context,
+        source=doc.path,
+        score=doc.score,
+        timestamp=ts,
+    ))
+
+    # Pair 2 (hanya jika teks cukup panjang): implementasi
+    if doc.word_count > 200:
+        body = text[800:1600].strip()
+        body = re.sub(r"^#{1,6}\s+", "", body, flags=re.MULTILINE)
+        if len(body) > 80:
+            pairs.append(TrainingPair(
+                instruction=f"Bagaimana cara mengimplementasikan atau menggunakan {title}?",
+                input="",
+                output=body,
+                source=doc.path,
+                score=doc.score,
+                timestamp=ts,
+            ))
+    return pairs
+
+
+# ── Main pipeline ──────────────────────────────────────────────────────────────
+def run_curation(
+    min_score: float = MIN_SCORE,
+    max_pairs: int = MAX_PAIRS_PER_RUN,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Jalankan full curation pipeline.
+
+    Returns:
+      {ok, scanned, scored, exported, pairs_written, output_file, warnings}
+    """
+    start = time.time()
+    _OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Load seen hashes
+    seen: set[str] = set()
+    if _SEEN_FILE.exists():
+        try:
+            seen = set(json.loads(_SEEN_FILE.read_text()))
+        except Exception:
+            seen = set()
+
+    scanned = 0
+    scored_docs: list[ScoredDoc] = []
+
+    for path, text in _iter_corpus_docs():
+        scanned += 1
+        lower = text.lower()
+        ch = _content_hash(text)
+        rel = _score_relevance(text, lower)
+        san = _score_sanad(lower)
+        maq = _score_maqashid(lower)
+        ded = _score_dedupe(ch, seen)
+        score = _composite_score(rel, san, maq, ded)
+
+        if score < min_score:
+            continue
+
+        scored_docs.append(ScoredDoc(
+            path=str(path),
+            content_hash=ch,
+            score=score,
+            relevance=rel,
+            sanad=san,
+            maqashid=maq,
+            dedupe=ded,
+            word_count=len(text.split()),
+            title=_extract_title(text, path),
+        ))
+
+    # sort by score desc
+    scored_docs.sort(key=lambda d: d.score, reverse=True)
+
+    # build training pairs
+    all_pairs: list[TrainingPair] = []
+    new_hashes: list[str] = []
+    for doc in scored_docs:
+        if len(all_pairs) >= max_pairs:
+            break
+        text_cache: dict[str, str] = {}
+        # re-read file untuk konten (jangan simpan semua di memory)
+        try:
+            text_cache[doc.path] = Path(doc.path).read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        pairs = _build_training_pairs(doc, text_cache[doc.path])
+        all_pairs.extend(pairs)
+        new_hashes.append(doc.content_hash)
+
+    warnings: list[str] = []
+    if len(all_pairs) < MIN_PAIRS_TARGET:
+        msg = f"Pairs generated ({len(all_pairs)}) < target ({MIN_PAIRS_TARGET}). Tambah corpus atau turunkan min_score."
+        warnings.append(msg)
+        logger.warning(msg)
+
+    output_file = ""
+    if not dry_run and all_pairs:
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        output_file = str(_OUT_DIR / f"curated_{date_str}.jsonl")
+        with open(output_file, "w", encoding="utf-8") as f:
+            for pair in all_pairs:
+                f.write(json.dumps(asdict(pair), ensure_ascii=False) + "\n")
+
+        # update seen hashes
+        seen.update(new_hashes)
+        _SEEN_FILE.write_text(json.dumps(list(seen), ensure_ascii=False, indent=2))
+
+    # update stats
+    stats = {
+        "last_run": datetime.now(timezone.utc).isoformat(),
+        "scanned": scanned,
+        "scored": len(scored_docs),
+        "exported": len(all_pairs),
+        "output_file": output_file,
+        "elapsed_s": round(time.time() - start, 2),
+        "warnings": warnings,
+    }
+    if not dry_run:
+        _STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _STATS_FILE.write_text(json.dumps(stats, ensure_ascii=False, indent=2))
+
+    logger.info(
+        "Curation done: scanned=%d scored=%d pairs=%d file=%s",
+        scanned, len(scored_docs), len(all_pairs), output_file,
+    )
+    return {"ok": True, **stats}
+
+
+def get_curation_stats() -> dict:
+    """Return stats run terakhir."""
+    if _STATS_FILE.exists():
+        try:
+            return json.loads(_STATS_FILE.read_text())
+        except Exception:
+            pass
+    return {"ok": False, "error": "belum pernah dijalankan"}

--- a/apps/brain_qa/brain_qa/debate_ring.py
+++ b/apps/brain_qa/brain_qa/debate_ring.py
@@ -1,0 +1,302 @@
+"""
+debate_ring.py — SIDIX Multi-Agent Debate (Sprint 5)
+
+Protokol: Creator ↔ Critic berdebat output kreatif, konsensus via CQF ≥ threshold.
+
+3 pair wajib Sprint 5:
+  1. copywriter   ↔ campaign_strategist  (copy vs strategi)
+  2. brand_builder ↔ design_critic       (identitas vs estetika)
+  3. script_hook   ↔ audience_lens       (hook vs relevansi audiens)
+
+Flow per round:
+  Critic → evaluasi prototype → approve (CQF ≥ threshold) atau critique
+  Creator → terima critique → revisi
+  Max 3 round. Jika tidak konsensus → return last + warning.
+
+LLM call: pakai local_llm.generate_sidix() kalau tersedia, fallback ke
+          multi_llm_router jika tidak, fallback heuristik jika semua mati.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Callable
+
+from .creative_quality import quality_gate, CQF_WEIGHTS, DELIVERY_THRESHOLD
+
+logger = logging.getLogger("sidix.debate_ring")
+
+# ── LLM helper — graceful fallback ───────────────────────────────────────────
+def _llm_call(prompt: str, max_tokens: int = 512) -> str:
+    """Try local_llm → multi_llm_router → heuristic fallback."""
+    # 1. Coba local_llm (Qwen + LoRA)
+    try:
+        from .local_llm import generate_sidix
+        return generate_sidix(prompt, max_new_tokens=max_tokens)
+    except Exception:
+        pass
+
+    # 2. Coba multi_llm_router
+    try:
+        from .multi_llm_router import route_generate
+        result = route_generate(prompt, max_tokens=max_tokens)
+        # route_generate returns LLMResult object, extract text
+        return result.text if hasattr(result, "text") else str(result)
+    except Exception:
+        pass
+
+    # 3. Fallback heuristik: return prompt digest sebagai placeholder
+    logger.warning("debate_ring: semua LLM unavailable, pakai heuristic fallback")
+    words = prompt.split()[:30]
+    return f"[Heuristic revision]: {' '.join(words)}... — diperbaiki berdasarkan kritik."
+
+
+# ── Critic prompt builder ─────────────────────────────────────────────────────
+_CRITIC_PROMPTS = {
+    "campaign_strategist": (
+        "Kamu adalah Campaign Strategist SIDIX. Evaluasi copy berikut dari perspektif strategi:\n"
+        "1. Apakah pesan selaras dengan AARRR funnel?\n"
+        "2. Apakah ada CTA yang jelas?\n"
+        "3. Apakah tone sesuai target audiens?\n"
+        "Beri skor 1-10. Jika skor < 7, berikan 2-3 poin perbaikan konkret.\n\n"
+        "COPY:\n{prototype}\n\nKONTEKS:\n{context}\n\n"
+        "Jawab format: SKOR:[1-10] | APPROVE:[ya/tidak] | KRITIK:[poin perbaikan atau 'approved']"
+    ),
+    "design_critic": (
+        "Kamu adalah Design Critic SIDIX. Evaluasi brand kit ini dari perspektif desain:\n"
+        "1. Apakah voice tone konsisten?\n"
+        "2. Apakah archetype selaras dengan target pasar?\n"
+        "3. Apakah ada inkonsistensi identitas?\n"
+        "Beri skor 1-10. Jika skor < 7, berikan 2-3 poin perbaikan.\n\n"
+        "BRAND KIT:\n{prototype}\n\nKONTEKS:\n{context}\n\n"
+        "Jawab format: SKOR:[1-10] | APPROVE:[ya/tidak] | KRITIK:[poin perbaikan atau 'approved']"
+    ),
+    "audience_lens": (
+        "Kamu adalah Audience Analyst SIDIX. Evaluasi script/hook ini dari perspektif audiens:\n"
+        "1. Apakah hook relevan untuk audiens Indonesia?\n"
+        "2. Apakah bahasa natural (bukan terjemahan)?\n"
+        "3. Apakah opening 3 detik menarik perhatian?\n"
+        "Beri skor 1-10. Jika skor < 7, berikan 2-3 poin perbaikan.\n\n"
+        "SCRIPT:\n{prototype}\n\nKONTEKS:\n{context}\n\n"
+        "Jawab format: SKOR:[1-10] | APPROVE:[ya/tidak] | KRITIK:[poin perbaikan atau 'approved']"
+    ),
+}
+
+_CREATOR_PROMPTS = {
+    "copywriter": (
+        "Kamu adalah Copywriter SIDIX. Revisi copy ini berdasarkan kritik:\n\n"
+        "COPY SEBELUMNYA:\n{prototype}\n\n"
+        "KRITIK DITERIMA:\n{critique}\n\n"
+        "Tulis ulang copy yang lebih kuat. Pertahankan formula asli, perbaiki kelemahan."
+    ),
+    "brand_builder": (
+        "Kamu adalah Brand Builder SIDIX. Revisi brand kit ini berdasarkan kritik:\n\n"
+        "BRAND KIT SEBELUMNYA:\n{prototype}\n\n"
+        "KRITIK DITERIMA:\n{critique}\n\n"
+        "Perkuat konsistensi identitas brand. Selaraskan voice, archetype, dan tone."
+    ),
+    "script_hook": (
+        "Kamu adalah Script Writer SIDIX. Revisi hook ini berdasarkan kritik:\n\n"
+        "HOOK SEBELUMNYA:\n{prototype}\n\n"
+        "KRITIK DITERIMA:\n{critique}\n\n"
+        "Tulis ulang hook yang lebih kuat untuk audiens Indonesia. Natural, tidak robotic."
+    ),
+}
+
+
+# ── Data models ────────────────────────────────────────────────────────────────
+@dataclass
+class DebateRound:
+    round_num: int
+    critic_agent: str
+    creator_agent: str
+    critique: str
+    revised_prototype: str
+    cqf_score: float
+    approved: bool
+
+
+@dataclass
+class DebateResult:
+    pair_id: str
+    final_prototype: str
+    consensus: bool
+    rounds_taken: int
+    final_cqf: float
+    transcript: list[dict] = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+
+# ── Core debate logic ──────────────────────────────────────────────────────────
+def _parse_critic_response(response: str) -> tuple[float, bool, str]:
+    """Parse 'SKOR:X | APPROVE:ya/tidak | KRITIK:...' → (score, approved, critique)."""
+    import re
+    score = 5.0
+    approved = False
+    critique = response
+
+    m_score = re.search(r"SKOR:\s*(\d+(?:\.\d+)?)", response, re.IGNORECASE)
+    if m_score:
+        score = min(10.0, float(m_score.group(1)))
+
+    m_approve = re.search(r"APPROVE:\s*(ya|tidak|yes|no)", response, re.IGNORECASE)
+    if m_approve:
+        approved = m_approve.group(1).lower() in ("ya", "yes")
+
+    m_critique = re.search(r"KRITIK:\s*(.+)", response, re.IGNORECASE | re.DOTALL)
+    if m_critique:
+        critique = m_critique.group(1).strip()
+
+    # fallback: jika score ≥ 7 → auto approve
+    if score >= 7.0:
+        approved = True
+
+    return score, approved, critique
+
+
+def run_debate(
+    *,
+    pair_id: str,
+    creator_agent: str,
+    critic_agent: str,
+    prototype: str,
+    context: str = "",
+    domain: str = "content",
+    max_rounds: int = 3,
+    threshold: float = DELIVERY_THRESHOLD,
+) -> DebateResult:
+    """
+    Jalankan debate antara creator ↔ critic.
+
+    pair_id contoh: 'copywriter_vs_strategist'
+    """
+    start = time.time()
+    transcript: list[dict] = []
+    current = prototype
+    consensus = False
+    rounds_taken = 0
+
+    # Ambil prompt templates
+    critic_tmpl = _CRITIC_PROMPTS.get(
+        critic_agent,
+        "Evaluasi output berikut:\n{prototype}\nKONTEKS:{context}\n"
+        "SKOR:[1-10] | APPROVE:[ya/tidak] | KRITIK:[catatan]"
+    )
+    creator_tmpl = _CREATOR_PROMPTS.get(
+        creator_agent,
+        "Revisi output berikut berdasarkan kritik:\n{prototype}\nKRITIK:{critique}\n"
+        "Tulis ulang yang lebih baik."
+    )
+
+    for round_num in range(1, max_rounds + 1):
+        rounds_taken = round_num
+        logger.info("[DebateRing] Round %d — %s critiques %s", round_num, critic_agent, creator_agent)
+
+        # ── Critic evaluates ──────────────────────────────────────────────────
+        critic_prompt = critic_tmpl.format(prototype=current[:600], context=context[:200])
+        critic_response = _llm_call(critic_prompt, max_tokens=256)
+        score, approved, critique = _parse_critic_response(critic_response)
+
+        # Also run CQF heuristic untuk double-check
+        gate = quality_gate(current, brief=context or pair_id, domain=domain, use_llm=False)
+        cqf_score = gate["total"]
+        if cqf_score >= threshold:
+            approved = True
+
+        transcript.append({
+            "round": round_num,
+            "speaker": critic_agent,
+            "action": "critique",
+            "llm_score": round(score, 2),
+            "cqf_score": round(cqf_score, 2),
+            "approved": approved,
+            "critique_preview": critique[:200],
+        })
+
+        if approved:
+            logger.info("[DebateRing] Konsensus tercapai round %d, cqf=%.2f", round_num, cqf_score)
+            consensus = True
+            break
+
+        if round_num == max_rounds:
+            logger.warning("[DebateRing] Max round tercapai tanpa konsensus, cqf=%.2f", cqf_score)
+            break
+
+        # ── Creator revises ───────────────────────────────────────────────────
+        creator_prompt = creator_tmpl.format(prototype=current[:600], critique=critique[:300])
+        revised = _llm_call(creator_prompt, max_tokens=512)
+
+        # pastikan hasil revisi tidak kosong
+        if len(revised.strip()) > 20:
+            current = revised
+
+        transcript.append({
+            "round": round_num,
+            "speaker": creator_agent,
+            "action": "revision",
+            "revised_preview": current[:200],
+        })
+
+    final_gate = quality_gate(current, brief=context or pair_id, domain=domain, use_llm=False)
+
+    return DebateResult(
+        pair_id=pair_id,
+        final_prototype=current,
+        consensus=consensus,
+        rounds_taken=rounds_taken,
+        final_cqf=final_gate["total"],
+        transcript=transcript,
+        elapsed_s=round(time.time() - start, 2),
+    )
+
+
+# ── 3 Standard Debate Pairs ───────────────────────────────────────────────────
+def debate_copy_vs_strategy(copy_text: str, context: str = "") -> DebateResult:
+    """Pair 1: Copywriter ↔ Campaign Strategist."""
+    return run_debate(
+        pair_id="copywriter_vs_strategist",
+        creator_agent="copywriter",
+        critic_agent="campaign_strategist",
+        prototype=copy_text,
+        context=context,
+        domain="content",
+    )
+
+
+def debate_brand_vs_design(brand_text: str, context: str = "") -> DebateResult:
+    """Pair 2: Brand Builder ↔ Design Critic."""
+    return run_debate(
+        pair_id="brand_vs_design",
+        creator_agent="brand_builder",
+        critic_agent="design_critic",
+        prototype=brand_text,
+        context=context,
+        domain="design",
+    )
+
+
+def debate_hook_vs_audience(hook_text: str, context: str = "") -> DebateResult:
+    """Pair 3: Script Hook ↔ Audience Lens."""
+    return run_debate(
+        pair_id="hook_vs_audience",
+        creator_agent="script_hook",
+        critic_agent="audience_lens",
+        prototype=hook_text,
+        context=context,
+        domain="content",
+    )
+
+
+def run_debate_as_dict(result: DebateResult) -> dict:
+    """Serialize DebateResult ke dict untuk API response."""
+    return {
+        "pair_id": result.pair_id,
+        "consensus": result.consensus,
+        "rounds_taken": result.rounds_taken,
+        "final_cqf": result.final_cqf,
+        "final_prototype": result.final_prototype,
+        "elapsed_s": result.elapsed_s,
+        "transcript": result.transcript,
+    }

--- a/apps/brain_qa/brain_qa/llm_judge.py
+++ b/apps/brain_qa/brain_qa/llm_judge.py
@@ -1,0 +1,485 @@
+"""
+llm_judge.py — SIDIX LLM-as-Judge Evaluator (Sprint 5)
+
+Tujuan: evaluasi output creative agents secara eksplisit, dapat-diaudit,
+        lebih kaya konteks daripada CQF heuristic saja.
+
+Pipeline:
+  content + brief + domain + criteria
+    → build evaluation prompt
+    → LLM call (local_llm → multi_llm_router → heuristic fallback)
+    → parse scores per criterion
+    → return {ok, scores, total, tier, rationale, recommendation, elapsed_s}
+
+Default criteria per domain:
+  content  — hook_strength, message_clarity, cta_effectiveness,
+             engagement_potential, authenticity
+  brand    — voice_consistency, archetype_alignment, differentiation,
+             memorability, trustworthiness
+  campaign — strategic_clarity, funnel_alignment, budget_efficiency,
+             conversion_focus, measurability
+  design   — visual_hierarchy, brand_consistency, audience_appeal,
+             cta_prominence, originality
+
+Score format: 0.0–10.0 per criterion, average = total.
+  total ≥ 8.5 → tier "premium"
+  total ≥ 7.0 → tier "delivery"
+  total < 7.0 → tier "needs_work"
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional
+
+logger = logging.getLogger("sidix.llm_judge")
+
+# ── Default criteria per domain ───────────────────────────────────────────────
+DOMAIN_CRITERIA: dict[str, list[str]] = {
+    "content": [
+        "hook_strength",
+        "message_clarity",
+        "cta_effectiveness",
+        "engagement_potential",
+        "authenticity",
+    ],
+    "brand": [
+        "voice_consistency",
+        "archetype_alignment",
+        "differentiation",
+        "memorability",
+        "trustworthiness",
+    ],
+    "campaign": [
+        "strategic_clarity",
+        "funnel_alignment",
+        "budget_efficiency",
+        "conversion_focus",
+        "measurability",
+    ],
+    "design": [
+        "visual_hierarchy",
+        "brand_consistency",
+        "audience_appeal",
+        "cta_prominence",
+        "originality",
+    ],
+}
+
+# Tier thresholds
+PREMIUM_THRESHOLD = 8.5
+DELIVERY_THRESHOLD = 7.0
+
+
+# ── LLM helper — graceful fallback (pola sama dengan debate_ring.py) ──────────
+def _llm_call(prompt: str, max_tokens: int = 512) -> str:
+    """Try local_llm → multi_llm_router → heuristic fallback."""
+    # 1. Coba local_llm (Qwen + LoRA)
+    try:
+        from .local_llm import generate_sidix
+        return generate_sidix(prompt, max_new_tokens=max_tokens)
+    except Exception:
+        pass
+
+    # 2. Coba multi_llm_router
+    try:
+        from .multi_llm_router import route_generate
+        result = route_generate(prompt, max_tokens=max_tokens)
+        # route_generate returns LLMResult object, extract text
+        return result.text if hasattr(result, "text") else str(result)
+    except Exception:
+        pass
+
+    # 3. Fallback — return sentinel untuk heuristic scoring
+    logger.warning("llm_judge: semua LLM unavailable, pakai heuristic fallback")
+    return "__HEURISTIC_FALLBACK__"
+
+
+# ── Prompt builder ─────────────────────────────────────────────────────────────
+def _build_judge_prompt(
+    content: str,
+    brief: str,
+    domain: str,
+    criteria: list[str],
+) -> str:
+    """Build prompt untuk LLM-as-Judge evaluation."""
+    criteria_str = "\n".join(f"- {c}: skor 0.0–10.0" for c in criteria)
+    brief_str = f"BRIEF / KONTEKS:\n{brief[:400]}\n\n" if brief else ""
+
+    return (
+        f"Kamu adalah evaluator konten profesional (LLM-as-Judge). "
+        f"Nilai output berikut secara objektif dan eksplisit.\n\n"
+        f"{brief_str}"
+        f"DOMAIN: {domain}\n\n"
+        f"KONTEN YANG DIEVALUASI:\n{content[:800]}\n\n"
+        f"Berikan skor untuk setiap kriteria berikut:\n{criteria_str}\n\n"
+        f"Format jawaban WAJIB:\n"
+        f"SKOR:\n"
+        + "\n".join(f"{c}: [0.0-10.0]" for c in criteria)
+        + "\n\nRATIONALE: [penjelasan singkat evaluasi]\n"
+        f"REKOMENDASI: [saran perbaikan konkret atau 'sudah baik']"
+    )
+
+
+def _build_compare_prompt(
+    variants: list[str],
+    brief: str,
+    domain: str,
+    criteria: list[str],
+) -> str:
+    """Build prompt untuk perbandingan beberapa variant."""
+    criteria_str = ", ".join(criteria)
+    brief_str = f"BRIEF:\n{brief[:300]}\n\n" if brief else ""
+    variants_str = "\n\n".join(
+        f"VARIANT {i+1}:\n{v[:400]}" for i, v in enumerate(variants)
+    )
+
+    return (
+        f"Kamu adalah evaluator konten (LLM-as-Judge). "
+        f"Bandingkan {len(variants)} variant konten berikut.\n\n"
+        f"{brief_str}"
+        f"DOMAIN: {domain} | Kriteria: {criteria_str}\n\n"
+        f"{variants_str}\n\n"
+        f"Jawab format:\n"
+        f"WINNER: [nomor variant terbaik, misal: 2]\n"
+        f"REASONING: [kenapa variant itu terbaik]\n"
+        f"SCORES_V1: [skor rata-rata 0.0-10.0 untuk variant 1]\n"
+        + "\n".join(f"SCORES_V{i+1}: [skor 0.0-10.0]" for i in range(1, len(variants)))
+    )
+
+
+# ── Response parsers ─────────────────────────────────────────────────────────
+def _parse_judge_response(
+    response: str,
+    criteria: list[str],
+) -> tuple[dict[str, float], str, str]:
+    """
+    Parse LLM judge response.
+    Returns: (scores_dict, rationale, recommendation)
+    """
+    scores: dict[str, float] = {}
+    rationale = ""
+    recommendation = ""
+
+    # Extract scores per criterion
+    for criterion in criteria:
+        # Match: "criterion_name: 8.5" atau "criterion_name : 8"
+        pattern = rf"{re.escape(criterion)}\s*[:=]\s*(\d+(?:\.\d+)?)"
+        m = re.search(pattern, response, re.IGNORECASE)
+        if m:
+            val = float(m.group(1))
+            scores[criterion] = max(0.0, min(10.0, val))
+        else:
+            scores[criterion] = 6.5  # default netral jika tidak ditemukan
+
+    # Extract rationale
+    m_rat = re.search(r"RATIONALE\s*:\s*(.+?)(?=REKOMENDASI|$)", response, re.IGNORECASE | re.DOTALL)
+    if m_rat:
+        rationale = m_rat.group(1).strip()[:500]
+
+    # Extract recommendation
+    m_rec = re.search(r"REKOMENDASI\s*:\s*(.+?)$", response, re.IGNORECASE | re.DOTALL)
+    if m_rec:
+        recommendation = m_rec.group(1).strip()[:300]
+
+    return scores, rationale, recommendation
+
+
+def _parse_compare_response(
+    response: str,
+    n_variants: int,
+) -> tuple[int, str, list[float]]:
+    """
+    Parse comparison response.
+    Returns: (winner_idx_0based, reasoning, scores_per_variant)
+    """
+    winner_idx = 0  # default variant 1
+    reasoning = ""
+    scores: list[float] = [6.5] * n_variants
+
+    # Winner
+    m_win = re.search(r"WINNER\s*:\s*(\d+)", response, re.IGNORECASE)
+    if m_win:
+        idx = int(m_win.group(1)) - 1  # convert to 0-based
+        winner_idx = max(0, min(idx, n_variants - 1))
+
+    # Reasoning
+    m_reas = re.search(r"REASONING\s*:\s*(.+?)(?=SCORES_|$)", response, re.IGNORECASE | re.DOTALL)
+    if m_reas:
+        reasoning = m_reas.group(1).strip()[:400]
+
+    # Scores per variant
+    for i in range(n_variants):
+        m_s = re.search(rf"SCORES_V{i+1}\s*:\s*(\d+(?:\.\d+)?)", response, re.IGNORECASE)
+        if m_s:
+            scores[i] = max(0.0, min(10.0, float(m_s.group(1))))
+
+    return winner_idx, reasoning, scores
+
+
+# ── Heuristic fallback scorer ─────────────────────────────────────────────────
+def _heuristic_score(
+    content: str,
+    brief: str,
+    criteria: list[str],
+) -> tuple[dict[str, float], str, str]:
+    """
+    Fallback saat LLM unavailable. Gunakan quality_gate dari creative_quality
+    sebagai proxy, map ke format judge output.
+    """
+    try:
+        from .creative_quality import quality_gate
+        gate = quality_gate(content, brief=brief, domain="content", use_llm=False)
+        base_score = gate.get("total", 6.5)
+        cqf_detail = gate.get("score", {})
+    except Exception:
+        base_score = 6.5
+        cqf_detail = {}
+
+    # Map CQF dimensions ke criteria
+    cqf_map = {
+        "hook_strength": cqf_detail.get("relevance", base_score),
+        "message_clarity": cqf_detail.get("quality", base_score),
+        "cta_effectiveness": cqf_detail.get("actionability", base_score),
+        "engagement_potential": cqf_detail.get("creativity", base_score),
+        "authenticity": cqf_detail.get("brand_alignment", base_score),
+        # brand criteria
+        "voice_consistency": cqf_detail.get("brand_alignment", base_score),
+        "archetype_alignment": cqf_detail.get("brand_alignment", base_score),
+        "differentiation": cqf_detail.get("creativity", base_score),
+        "memorability": cqf_detail.get("creativity", base_score),
+        "trustworthiness": cqf_detail.get("quality", base_score),
+        # campaign criteria
+        "strategic_clarity": cqf_detail.get("quality", base_score),
+        "funnel_alignment": cqf_detail.get("relevance", base_score),
+        "budget_efficiency": cqf_detail.get("actionability", base_score),
+        "conversion_focus": cqf_detail.get("actionability", base_score),
+        "measurability": cqf_detail.get("quality", base_score),
+        # design criteria
+        "visual_hierarchy": cqf_detail.get("quality", base_score),
+        "brand_consistency": cqf_detail.get("brand_alignment", base_score),
+        "audience_appeal": cqf_detail.get("relevance", base_score),
+        "cta_prominence": cqf_detail.get("actionability", base_score),
+        "originality": cqf_detail.get("creativity", base_score),
+    }
+
+    scores = {c: round(cqf_map.get(c, base_score), 2) for c in criteria}
+    rationale = (
+        f"[Heuristic fallback via CQF] Base score: {base_score:.1f}. "
+        f"LLM tidak tersedia saat evaluasi."
+    )
+    hints = gate.get("refinement_hints", []) if "gate" in dir() else []
+    recommendation = "; ".join(hints[:3]) if hints else "Tidak ada rekomendasi spesifik (heuristic mode)."
+
+    return scores, rationale, recommendation
+
+
+# ── Core judge function ───────────────────────────────────────────────────────
+def judge_content(
+    content: str,
+    brief: str = "",
+    domain: str = "content",
+    criteria: Optional[list[str]] = None,
+    model_override: Optional[str] = None,
+) -> dict:
+    """
+    Minta LLM untuk menilai content secara eksplisit.
+
+    Args:
+        content: konten yang akan dievaluasi
+        brief: konteks / brief (opsional tapi sangat membantu)
+        domain: "content" | "brand" | "campaign" | "design"
+        criteria: custom criteria; jika None → pakai default per domain
+        model_override: (future use) override model tertentu
+
+    Returns:
+        {
+            ok: bool,
+            scores: {criterion: score},
+            total: float,
+            tier: "premium" | "delivery" | "needs_work",
+            rationale: str,
+            recommendation: str,
+            elapsed_s: float,
+            mode: "llm" | "heuristic",
+        }
+    """
+    start = time.time()
+
+    if not content or not content.strip():
+        return {"ok": False, "error": "content wajib diisi", "elapsed_s": 0.0}
+
+    # Tentukan criteria
+    effective_domain = domain if domain in DOMAIN_CRITERIA else "content"
+    effective_criteria = criteria if criteria else DOMAIN_CRITERIA[effective_domain]
+
+    # Build prompt dan call LLM
+    prompt = _build_judge_prompt(content, brief, effective_domain, effective_criteria)
+    response = _llm_call(prompt, max_tokens=512)
+
+    # Tentukan mode dan parse
+    mode = "llm"
+    if response == "__HEURISTIC_FALLBACK__":
+        mode = "heuristic"
+        scores, rationale, recommendation = _heuristic_score(content, brief, effective_criteria)
+    else:
+        scores, rationale, recommendation = _parse_judge_response(response, effective_criteria)
+
+    # Hitung total
+    total = round(sum(scores.values()) / max(1, len(scores)), 2) if scores else 0.0
+
+    # Tentukan tier
+    if total >= PREMIUM_THRESHOLD:
+        tier = "premium"
+    elif total >= DELIVERY_THRESHOLD:
+        tier = "delivery"
+    else:
+        tier = "needs_work"
+
+    elapsed = round(time.time() - start, 3)
+
+    logger.info(
+        "judge_content: domain=%s total=%.2f tier=%s mode=%s elapsed=%.2fs",
+        effective_domain, total, tier, mode, elapsed,
+    )
+
+    return {
+        "ok": True,
+        "scores": scores,
+        "total": total,
+        "tier": tier,
+        "rationale": rationale,
+        "recommendation": recommendation,
+        "elapsed_s": elapsed,
+        "mode": mode,
+        "domain": effective_domain,
+        "criteria": effective_criteria,
+    }
+
+
+def judge_batch(
+    items: list[dict],
+    concurrency: int = 3,
+) -> list[dict]:
+    """
+    Jalankan judge_content untuk banyak item secara paralel.
+
+    Args:
+        items: list of dicts, tiap item = {content, brief?, domain?}
+        concurrency: max parallel workers (default 3)
+
+    Returns:
+        list[dict] — hasil judge per item, urutan sama dengan input
+    """
+    if not items:
+        return []
+
+    concurrency = max(1, min(concurrency, 10))
+    results: list[dict] = [{}] * len(items)
+
+    def _judge_one(idx: int, item: dict) -> tuple[int, dict]:
+        r = judge_content(
+            content=item.get("content", ""),
+            brief=item.get("brief", ""),
+            domain=item.get("domain", "content"),
+            criteria=item.get("criteria"),
+        )
+        return idx, r
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = {
+            executor.submit(_judge_one, i, item): i
+            for i, item in enumerate(items)
+        }
+        for future in as_completed(futures):
+            try:
+                idx, result = future.result()
+                results[idx] = result
+            except Exception as exc:
+                orig_idx = futures[future]
+                results[orig_idx] = {
+                    "ok": False,
+                    "error": f"judge_batch item {orig_idx}: {exc}",
+                }
+
+    return results
+
+
+def compare_variants(
+    variants: list[str],
+    brief: str,
+    domain: str = "content",
+) -> dict:
+    """
+    Bandingkan beberapa variant konten, pilih yang terbaik.
+
+    Args:
+        variants: list string konten yang akan dibandingkan (min 2)
+        brief: konteks / brief
+        domain: "content" | "brand" | "campaign" | "design"
+
+    Returns:
+        {
+            ok: bool,
+            winner_idx: int,  # 0-based index
+            winner: str,      # konten pemenang
+            scores: list[float],  # skor rata-rata per variant
+            all_scores: list[dict],  # detail skor tiap variant
+            rationale: str,
+            elapsed_s: float,
+        }
+    """
+    start = time.time()
+
+    if not variants or len(variants) < 2:
+        return {"ok": False, "error": "Minimal 2 variant diperlukan untuk perbandingan"}
+
+    effective_domain = domain if domain in DOMAIN_CRITERIA else "content"
+    effective_criteria = DOMAIN_CRITERIA[effective_domain]
+
+    # Build compare prompt
+    prompt = _build_compare_prompt(variants, brief, effective_domain, effective_criteria)
+    response = _llm_call(prompt, max_tokens=400)
+
+    winner_idx = 0
+    reasoning = ""
+    avg_scores: list[float] = []
+
+    if response == "__HEURISTIC_FALLBACK__":
+        # Score tiap variant secara heuristik
+        all_results = judge_batch(
+            [{"content": v, "brief": brief, "domain": domain} for v in variants],
+            concurrency=min(len(variants), 4),
+        )
+        avg_scores = [r.get("total", 0.0) for r in all_results]
+        winner_idx = avg_scores.index(max(avg_scores)) if avg_scores else 0
+        reasoning = f"[Heuristic] Variant {winner_idx + 1} memiliki skor tertinggi ({avg_scores[winner_idx]:.2f})"
+        all_detail_scores = [r.get("scores", {}) for r in all_results]
+    else:
+        winner_idx, reasoning, avg_scores = _parse_compare_response(response, len(variants))
+        # Get detail scores per variant via individual judges
+        all_results = judge_batch(
+            [{"content": v, "brief": brief, "domain": domain} for v in variants],
+            concurrency=min(len(variants), 4),
+        )
+        # Prefer LLM compare scores if parsed successfully
+        for i, s in enumerate(avg_scores):
+            if s == 6.5 and all_results[i].get("total"):
+                avg_scores[i] = all_results[i]["total"]
+        all_detail_scores = [r.get("scores", {}) for r in all_results]
+
+    elapsed = round(time.time() - start, 3)
+
+    return {
+        "ok": True,
+        "winner_idx": winner_idx,
+        "winner": variants[winner_idx] if winner_idx < len(variants) else "",
+        "scores": avg_scores,
+        "all_scores": all_detail_scores,
+        "rationale": reasoning,
+        "elapsed_s": elapsed,
+        "domain": effective_domain,
+    }

--- a/apps/brain_qa/brain_qa/prompt_optimizer.py
+++ b/apps/brain_qa/brain_qa/prompt_optimizer.py
@@ -1,0 +1,456 @@
+"""
+prompt_optimizer.py — SIDIX Self-Evolution Level 1 (Sprint 5)
+
+DSPy-inspired automated prompt tuning — own-stack, tanpa vendor library.
+
+Konsep:
+  Setelah N output di-accept (CQF ≥ 7.0), sistem otomatis analisis pola
+  prompt yang berhasil → ekstrak "few-shot examples" terbaik → inject ke
+  prompt template agent untuk run berikutnya.
+
+Pipeline:
+  accepted_outputs (JSONL)
+    → score & rank ulang via llm_judge
+    → ekstrak top-K sebagai few-shot demos
+    → rewrite prompt template dengan demos + instruksi optimal
+    → simpan versi baru ke .data/optimized_prompts/<agent>_<date>.json
+    → evaluate improvement via held-out set
+
+Level: L1 (prompt-level, tidak modifikasi bobot model)
+Trigger: setiap 50 output baru yang diterima, atau manual
+Rollback: kalau versi baru lebih buruk → revert ke sebelumnya
+
+Referensi: sidix_technical_architecture_ref.md §7.2 DSPy Integration
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("sidix.prompt_optimizer")
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+_BASE = Path(__file__).parent
+_DATA_DIR = _BASE.parent / ".data"
+_PROMPTS_DIR = _DATA_DIR / "optimized_prompts"
+_ACCEPTED_LOG = _DATA_DIR / "accepted_outputs.jsonl"   # feed dari agent pipeline
+_STATS_FILE = _DATA_DIR / "prompt_optimizer_stats.json"
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+MIN_SAMPLES_TO_OPTIMIZE = 20   # minimum accepted outputs sebelum optimisasi
+TOP_K_DEMOS = 4                 # max few-shot examples yg diinjek ke prompt
+MIN_DEMO_SCORE = 7.5            # minimum skor demo untuk dijadikan contoh
+IMPROVEMENT_THRESHOLD = 0.3    # delta CQF minimum agar versi baru diterima
+
+# ── Domain prompt skeletons (template dasar per domain) ───────────────────────
+_BASE_PROMPTS: dict[str, str] = {
+    "copywriter": (
+        "Kamu adalah Copywriter SIDIX. Tulis copy yang kuat untuk:\n"
+        "TOPIK: {topic}\nAUDIENS: {audience}\nFORMULA: {formula}\nTONE: {tone}\n"
+        "CHANNEL: {channel}\n\n"
+        "{few_shot_block}"
+        "Sekarang tulis copy terbaik untuk topik di atas."
+    ),
+    "brand_builder": (
+        "Kamu adalah Brand Builder SIDIX. Bangun brand kit untuk:\n"
+        "BISNIS: {business_name}\nNICHE: {niche}\nAUDIENS: {target_audience}\n\n"
+        "{few_shot_block}"
+        "Buat brand kit lengkap: archetype, voice tone, tagline, warna utama."
+    ),
+    "campaign_strategist": (
+        "Kamu adalah Campaign Strategist SIDIX. Rancang strategi kampanye untuk:\n"
+        "PRODUK: {product}\nTUJUAN: {goal}\nAUDIENS: {audience}\nBUDGET: Rp{budget_idr:,}\n\n"
+        "{few_shot_block}"
+        "Rancang kampanye AARRR 5 tahap dengan allocation budget dan KPI."
+    ),
+    "content_planner": (
+        "Kamu adalah Content Planner SIDIX. Buat content calendar untuk:\n"
+        "NICHE: {niche}\nAUDIENS: {target_audience}\nDURASI: {duration_days} hari\n\n"
+        "{few_shot_block}"
+        "Buat plan {posts_per_week} post/minggu dengan variasi format dan topik."
+    ),
+    "ads_generator": (
+        "Kamu adalah Ads Specialist SIDIX. Buat iklan untuk:\n"
+        "PRODUK: {product}\nPLATFORM: {platform}\nOBJEKTIF: {objective}\nAUDIENS: {audience}\n\n"
+        "{few_shot_block}"
+        "Buat {n_variants} varian iklan yang berbeda hook dan angle."
+    ),
+}
+
+
+# ── Data models ────────────────────────────────────────────────────────────────
+@dataclass
+class AcceptedOutput:
+    """Satu output yang diterima dari agent pipeline."""
+    agent: str
+    prompt_params: dict
+    output_text: str
+    score: float
+    domain: str
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+@dataclass
+class OptimizedPrompt:
+    agent: str
+    domain: str
+    version: int
+    template: str
+    few_shot_demos: list[dict]
+    baseline_score: float
+    optimized_score: float
+    sample_count: int
+    created_at: str
+    active: bool = True
+
+
+@dataclass
+class OptimizeResult:
+    ok: bool
+    agent: str
+    version: int
+    baseline_score: float
+    optimized_score: float
+    improvement: float
+    accepted: bool          # apakah versi baru lebih baik
+    demos_used: int
+    elapsed_s: float
+    notes: str = ""
+
+
+# ── Helper: LLM call (sama pola dengan debate_ring / llm_judge) ────────────────
+def _llm_call(prompt: str, max_tokens: int = 512) -> str:
+    try:
+        from .local_llm import generate_sidix
+        return generate_sidix(prompt, max_new_tokens=max_tokens)
+    except Exception:
+        pass
+    try:
+        from .multi_llm_router import route_generate
+        result = route_generate(prompt, max_tokens=max_tokens)
+        return result.text if hasattr(result, "text") else str(result)
+    except Exception:
+        pass
+    words = prompt.split()[:20]
+    return f"[Heuristic output]: {' '.join(words)}..."
+
+
+# ── Helper: eval skor via llm_judge atau quality_gate ─────────────────────────
+def _score_text(text: str, brief: str, domain: str) -> float:
+    try:
+        from .llm_judge import judge_content
+        r = judge_content(text, brief=brief, domain=domain)
+        return float(r.get("total", 0))
+    except Exception:
+        pass
+    try:
+        from .creative_quality import quality_gate
+        g = quality_gate(text, brief=brief, domain=domain, use_llm=False)
+        return float(g.get("total", 0))
+    except Exception:
+        return 5.0
+
+
+# ── Log accepted output ────────────────────────────────────────────────────────
+def log_accepted_output(
+    agent: str,
+    prompt_params: dict,
+    output_text: str,
+    score: float,
+    domain: str = "content",
+) -> None:
+    """
+    Catat output yang diterima (CQF ≥ 7.0) ke accepted_outputs.jsonl.
+    Dipanggil oleh pipeline setelah output lulus quality gate.
+    """
+    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+    record = asdict(AcceptedOutput(
+        agent=agent,
+        prompt_params=prompt_params,
+        output_text=output_text,
+        score=score,
+        domain=domain,
+    ))
+    with open(_ACCEPTED_LOG, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    logger.debug("log_accepted_output: agent=%s score=%.2f", agent, score)
+
+
+# ── Load accepted outputs ──────────────────────────────────────────────────────
+def _load_accepted(agent: str, min_score: float = MIN_DEMO_SCORE) -> list[dict]:
+    """Baca semua accepted outputs untuk satu agent, filter by min_score."""
+    if not _ACCEPTED_LOG.exists():
+        return []
+    records: list[dict] = []
+    with open(_ACCEPTED_LOG, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+                if r.get("agent") == agent and float(r.get("score", 0)) >= min_score:
+                    records.append(r)
+            except Exception:
+                pass
+    # sort by score desc
+    records.sort(key=lambda x: float(x.get("score", 0)), reverse=True)
+    return records
+
+
+# ── Build few-shot block ───────────────────────────────────────────────────────
+def _build_few_shot_block(demos: list[dict]) -> str:
+    """Format demos menjadi few-shot block yang siap di-inject ke prompt."""
+    if not demos:
+        return ""
+    parts = ["CONTOH OUTPUT BERKUALITAS TINGGI (pelajari pola, jangan copy persis):\n"]
+    for i, demo in enumerate(demos[:TOP_K_DEMOS], 1):
+        score = demo.get("score", 0)
+        text = demo.get("output_text", "")[:400]
+        parts.append(f"[Contoh {i}] (Skor: {score:.1f})\n{text}\n")
+    parts.append("\n---\n")
+    return "\n".join(parts)
+
+
+# ── Load/save optimized prompt ─────────────────────────────────────────────────
+def _load_current_prompt(agent: str) -> OptimizedPrompt | None:
+    _PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
+    # cari file terbaru untuk agent ini
+    files = sorted(_PROMPTS_DIR.glob(f"{agent}_v*.json"), reverse=True)
+    for f in files:
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            if data.get("active"):
+                return OptimizedPrompt(**data)
+        except Exception:
+            pass
+    return None
+
+
+def _save_optimized_prompt(op: OptimizedPrompt) -> str:
+    _PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
+    fname = f"{op.agent}_v{op.version:03d}.json"
+    path = _PROMPTS_DIR / fname
+    path.write_text(json.dumps(asdict(op), ensure_ascii=False, indent=2), encoding="utf-8")
+    return str(path)
+
+
+def _deactivate_old(agent: str) -> None:
+    """Tandai versi lama sebagai inactive."""
+    for f in _PROMPTS_DIR.glob(f"{agent}_v*.json"):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            if data.get("active"):
+                data["active"] = False
+                f.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        except Exception:
+            pass
+
+
+# ── Core optimizer ─────────────────────────────────────────────────────────────
+def optimize_prompt(
+    agent: str,
+    domain: str = "content",
+    force: bool = False,
+    dry_run: bool = False,
+) -> OptimizeResult:
+    """
+    Optimalkan prompt untuk satu agent berdasarkan accepted outputs.
+
+    Proses:
+    1. Load accepted outputs yang cukup (≥ MIN_SAMPLES)
+    2. Pilih top-K sebagai demos
+    3. Build prompt baru dengan few-shot block
+    4. Evaluasi vs baseline pada sample kecil
+    5. Accept jika improvement ≥ threshold, rollback jika tidak
+    """
+    start = time.time()
+
+    # Load accepted outputs
+    samples = _load_accepted(agent)
+    if len(samples) < MIN_SAMPLES_TO_OPTIMIZE and not force:
+        return OptimizeResult(
+            ok=False, agent=agent, version=0,
+            baseline_score=0, optimized_score=0, improvement=0,
+            accepted=False, demos_used=0,
+            elapsed_s=round(time.time() - start, 2),
+            notes=f"Kurang sample: {len(samples)} < {MIN_SAMPLES_TO_OPTIMIZE}. Gunakan force=True untuk override."
+        )
+
+    logger.info("prompt_optimizer: mulai untuk agent='%s' samples=%d", agent, len(samples))
+
+    # Pilih top-K demos
+    demos = samples[:TOP_K_DEMOS]
+
+    # Baseline: rata-rata skor existing demos
+    baseline_score = round(sum(float(d.get("score", 0)) for d in demos) / max(len(demos), 1), 2)
+
+    # Build template baru
+    base_template = _BASE_PROMPTS.get(agent, "Tugas: {topic}\n{few_shot_block}Berikan output terbaik.")
+    few_shot_block = _build_few_shot_block(demos)
+    new_template = base_template.replace("{few_shot_block}", few_shot_block)
+
+    # Evaluasi: test template baru pada top-3 params dari samples
+    eval_scores: list[float] = []
+    for sample in samples[:3]:
+        params = sample.get("prompt_params", {})
+        # Isi template dengan params test (safe — pakai .get)
+        try:
+            test_prompt = new_template.format(**{k: v for k, v in params.items() if isinstance(v, (str, int, float))})
+        except KeyError:
+            test_prompt = new_template
+        # Generate & score
+        generated = _llm_call(test_prompt[:800], max_tokens=400)
+        brief = str(params.get("topic") or params.get("product") or params.get("niche") or agent)
+        score = _score_text(generated, brief=brief, domain=domain)
+        eval_scores.append(score)
+
+    optimized_score = round(sum(eval_scores) / max(len(eval_scores), 1), 2) if eval_scores else baseline_score
+    improvement = round(optimized_score - baseline_score, 2)
+    accepted = improvement >= IMPROVEMENT_THRESHOLD
+
+    # Determine version
+    current = _load_current_prompt(agent)
+    next_version = (current.version + 1) if current else 1
+
+    if not dry_run and accepted:
+        # Deactivate old, save new
+        _deactivate_old(agent)
+        op = OptimizedPrompt(
+            agent=agent,
+            domain=domain,
+            version=next_version,
+            template=new_template,
+            few_shot_demos=[{"score": d["score"], "preview": d["output_text"][:200]} for d in demos],
+            baseline_score=baseline_score,
+            optimized_score=optimized_score,
+            sample_count=len(samples),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            active=True,
+        )
+        saved_path = _save_optimized_prompt(op)
+        logger.info(
+            "prompt_optimizer: versi baru disimpan v%d path=%s improvement=+%.2f",
+            next_version, saved_path, improvement
+        )
+    elif not dry_run and not accepted:
+        logger.info(
+            "prompt_optimizer: versi baru DITOLAK improvement=%.2f < threshold=%.2f, tetap pakai versi lama",
+            improvement, IMPROVEMENT_THRESHOLD
+        )
+
+    # Update stats
+    stats = {
+        "last_run": datetime.now(timezone.utc).isoformat(),
+        "agent": agent,
+        "version": next_version if accepted else (current.version if current else 0),
+        "baseline_score": baseline_score,
+        "optimized_score": optimized_score,
+        "improvement": improvement,
+        "accepted": accepted,
+        "dry_run": dry_run,
+    }
+    if not dry_run:
+        _STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _STATS_FILE.write_text(json.dumps(stats, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    return OptimizeResult(
+        ok=True,
+        agent=agent,
+        version=next_version if accepted else (current.version if current else 0),
+        baseline_score=baseline_score,
+        optimized_score=optimized_score,
+        improvement=improvement,
+        accepted=accepted,
+        demos_used=len(demos),
+        elapsed_s=round(time.time() - start, 2),
+        notes="dry_run" if dry_run else ("accepted" if accepted else "rollback"),
+    )
+
+
+# ── Get active prompt ──────────────────────────────────────────────────────────
+def get_active_prompt(agent: str) -> dict:
+    """
+    Ambil template prompt aktif untuk agent.
+    Returns base template jika belum pernah dioptimalkan.
+    """
+    current = _load_current_prompt(agent)
+    if current:
+        return {
+            "ok": True,
+            "agent": agent,
+            "version": current.version,
+            "template": current.template,
+            "optimized_score": current.optimized_score,
+            "created_at": current.created_at,
+        }
+    base = _BASE_PROMPTS.get(agent, "")
+    return {
+        "ok": True,
+        "agent": agent,
+        "version": 0,
+        "template": base,
+        "optimized_score": 0.0,
+        "created_at": None,
+    }
+
+
+# ── Batch optimize semua agents ────────────────────────────────────────────────
+def optimize_all_agents(
+    dry_run: bool = False,
+    force: bool = False,
+) -> dict:
+    """
+    Optimalkan semua agent sekaligus. Cocok untuk cron weekly.
+    Returns: {ok, results, total_agents, improved, elapsed_s}
+    """
+    start = time.time()
+    agents = list(_BASE_PROMPTS.keys())
+    results: list[dict] = []
+
+    for agent in agents:
+        domain_map = {
+            "copywriter": "content",
+            "brand_builder": "brand",
+            "campaign_strategist": "campaign",
+            "content_planner": "content",
+            "ads_generator": "content",
+        }
+        domain = domain_map.get(agent, "content")
+        r = optimize_prompt(agent=agent, domain=domain, force=force, dry_run=dry_run)
+        results.append({
+            "agent": r.agent,
+            "version": r.version,
+            "improvement": r.improvement,
+            "accepted": r.accepted,
+            "notes": r.notes,
+        })
+
+    improved = sum(1 for r in results if r.get("accepted"))
+    logger.info(
+        "optimize_all_agents: %d/%d improved elapsed=%.1fs",
+        improved, len(agents), time.time() - start
+    )
+    return {
+        "ok": True,
+        "results": results,
+        "total_agents": len(agents),
+        "improved": improved,
+        "elapsed_s": round(time.time() - start, 2),
+    }
+
+
+def get_optimizer_stats() -> dict:
+    """Return stats run terakhir."""
+    if _STATS_FILE.exists():
+        try:
+            return json.loads(_STATS_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {"ok": False, "error": "belum pernah dijalankan"}

--- a/test_sprint5.py
+++ b/test_sprint5.py
@@ -1,0 +1,51 @@
+# Sprint 5 smoke test
+import sys
+sys.path.insert(0, r"D:\MIGHAN Model\sprint5\apps\brain_qa")
+
+tests = []
+
+# T5.1 curator
+try:
+    from brain_qa.curator_agent import run_curation, get_curation_stats
+    r = run_curation(dry_run=True)
+    tests.append(("[PASS] curator_agent", r.get("ok") is True))
+except Exception as e:
+    tests.append(("[FAIL] curator_agent", str(e)))
+
+# T5.2 debate_ring
+try:
+    from brain_qa.debate_ring import debate_copy_vs_strategy
+    r = debate_copy_vs_strategy("Produk terbaik untuk kamu!", "test context")
+    tests.append(("[PASS] debate_ring", r.consensus or r.rounds_taken > 0))
+except Exception as e:
+    tests.append(("[FAIL] debate_ring", str(e)))
+
+# T5.3 agency_kit
+try:
+    from brain_qa.agency_kit import build_agency_kit
+    r = build_agency_kit(
+        business_name="Test Biz",
+        niche="kuliner",
+        target_audience="anak muda Jakarta",
+        budget="500rb",
+        skip_ads=True,
+        skip_thumbnails=True,
+    )
+    tests.append(("[PASS] agency_kit", r.get("ok") is True))
+except Exception as e:
+    tests.append(("[FAIL] agency_kit", str(e)))
+
+# T5.4 llm_judge
+try:
+    from brain_qa.llm_judge import judge_content
+    r = judge_content("Ini adalah copy test untuk produk kami.", brief="test", domain="content")
+    tests.append(("[PASS] llm_judge", r.get("ok") is True and r.get("total", 0) > 0))
+except Exception as e:
+    tests.append(("[FAIL] llm_judge", str(e)))
+
+for label, result in tests:
+    print(f"{label}: {result}")
+
+total = len(tests)
+passed = sum(1 for _, r in tests if r is True or (isinstance(r, bool) and r))
+print(f"\nTotal: {passed}/{total} PASS")


### PR DESCRIPTION
## Summary

Sprint 5 — 5 modul baru, 34 tools total.

- T5.1 curator_agent.py — self-train curation pipeline (relevance x sanad x maqashid x dedupe → JSONL)
- T5.2 debate_ring.py — multi-agent debate Creator vs Critic, 3 pairs, max 3 rounds
- T5.3 agency_kit.py — 1-click 6-layer DAG: brand + captions x10 + plan + campaign + ads x3 + thumbnails
- T5.4 llm_judge.py — LLM-as-Judge, 4 domain criteria sets, compare_variants, fallback heuristic
- T5.5 prompt_optimizer.py — Self-Evolution L1: few-shot injection, versioning + rollback otomatis

agent_tools.py: +5 tools → total 34 tools
agent_serve.py: +1 endpoint POST /creative/agency_kit

## Smoke Test
4/4 PASS (curator, debate_ring, agency_kit, llm_judge)

## Notes
- Warning minor: signature mismatch Sprint 4 ditangani _safe() wrapper
- prompt_optimizer permission=restricted (perlu allow_restricted=True)