### PR TITLE
feat: Sprint 6 — flywheel L1 aktif + signature fix + cron optimizer

### DIFF
--- a/apps/brain_qa/brain_qa/agent_serve.py
+++ b/apps/brain_qa/brain_qa/agent_serve.py
@@ -3168,6 +3168,71 @@ h1{{color:#0af}}p{{color:#aaa}}a{{color:#0af}}</style></head>
         except Exception as e:
             return {"ok": False, "error": str(e)}
 
+    # ── Sprint 6: Prompt Optimizer endpoints ────────────────────────────────
+    @app.post("/creative/prompt_optimize/all", tags=["Creative"])
+    async def creative_prompt_optimize_all(request: Request):
+        """
+        Jalankan optimize_all_agents() untuk semua domain creative.
+        Admin-only. Cocok dipanggil via cron: Senin 04:00 UTC.
+
+        Cron example (crontab VPS):
+          0 4 * * MON curl -s -X POST https://ctrl.sidixlab.com/creative/prompt_optimize/all \\
+            -H "X-Admin-Token: $BRAIN_QA_ADMIN_TOKEN"
+
+        Body (opsional):
+          dry_run (bool, default false) — simulasi tanpa tulis file
+          force   (bool, default false) — paksa meski sample kurang dari minimum
+        """
+        if not _admin_ok(request):
+            raise HTTPException(status_code=403, detail="admin token diperlukan")
+        body: dict = {}
+        try:
+            body = await request.json()
+        except Exception:
+            pass
+        dry_run = bool((body or {}).get("dry_run", False))
+        force = bool((body or {}).get("force", False))
+        try:
+            from .prompt_optimizer import optimize_all_agents
+            result = optimize_all_agents(dry_run=dry_run, force=force)
+            return result
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    @app.post("/creative/prompt_optimize/{agent}", tags=["Creative"])
+    async def creative_prompt_optimize_one(agent: str, request: Request):
+        """
+        Optimalkan prompt untuk satu agent. Admin-only.
+        agent: copywriter | brand_builder | campaign_strategist | content_planner | ads_generator
+
+        Body (opsional): dry_run (bool), force (bool)
+        """
+        if not _admin_ok(request):
+            raise HTTPException(status_code=403, detail="admin token diperlukan")
+        body: dict = {}
+        try:
+            body = await request.json()
+        except Exception:
+            pass
+        dry_run = bool((body or {}).get("dry_run", False))
+        force = bool((body or {}).get("force", False))
+        try:
+            from .prompt_optimizer import optimize_prompt, get_optimizer_stats
+            result = optimize_prompt(agent=agent, force=force, dry_run=dry_run)
+            from dataclasses import asdict
+            return asdict(result)
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    @app.get("/creative/prompt_optimize/stats", tags=["Creative"])
+    def creative_prompt_optimize_stats():
+        """Statistik run optimize terakhir. Public read-only."""
+        try:
+            from .prompt_optimizer import get_optimizer_stats
+            return get_optimizer_stats()
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
     # ── Concept graph endpoint (Sprint 1 T1.4) ───────────────────────────────
     @app.get("/concept_graph/query")
     def concept_graph_query(request: Request, concept: str = "", depth: int = 1, max_related: int = 5):

--- a/apps/brain_qa/brain_qa/agent_tools.py
+++ b/apps/brain_qa/brain_qa/agent_tools.py
@@ -136,6 +136,7 @@ def _tool_generate_content_plan(args: dict) -> ToolResult:
 
         result = generate_content_plan(
             niche=str(args.get("niche", "")).strip(),
+            target_audience=str(args.get("target_audience", "")).strip(),
             duration_days=int(args.get("duration_days", 30)),
             channel=str(args.get("channel", "instagram")).strip() or "instagram",
             cadence_per_week=int(args.get("cadence_per_week", 5)),
@@ -182,6 +183,7 @@ def _tool_generate_brand_kit(args: dict) -> ToolResult:
         result = generate_brand_kit(
             business_name=str(args.get("business_name", "")).strip(),
             niche=str(args.get("niche", "")).strip(),
+            target_audience=str(args.get("target_audience", "")).strip(),
             vibe=str(args.get("vibe", "modern, warm, trustworthy")).strip(),
             archetype=str(args.get("archetype", "")).strip() or None,
         )
@@ -2111,9 +2113,9 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         name="generate_content_plan",
         description=(
             "Generate kalender konten (JSON) sesuai niche + channel + durasi. "
-            "Params: niche (wajib), duration_days, channel, cadence_per_week, objective."
+            "Params: niche (wajib), target_audience, duration_days, channel, cadence_per_week, objective."
         ),
-        params=["niche", "duration_days", "channel", "cadence_per_week", "objective"],
+        params=["niche", "target_audience", "duration_days", "channel", "cadence_per_week", "objective"],
         permission="open",
         fn=_tool_generate_content_plan,
     ),
@@ -2121,9 +2123,9 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         name="generate_brand_kit",
         description=(
             "Generate brand kit: archetype, palette, tone, onlyness, golden circle, logo prompts. "
-            "Params: business_name (wajib), niche (wajib), vibe, archetype."
+            "Params: business_name (wajib), niche (wajib), target_audience, vibe, archetype."
         ),
-        params=["business_name", "niche", "vibe", "archetype"],
+        params=["business_name", "niche", "target_audience", "vibe", "archetype"],
         permission="open",
         fn=_tool_generate_brand_kit,
     ),

--- a/apps/brain_qa/brain_qa/brand_builder.py
+++ b/apps/brain_qa/brain_qa/brand_builder.py
@@ -45,11 +45,13 @@ def generate_brand_kit(
     *,
     business_name: str,
     niche: str,
+    target_audience: str = "",
     vibe: str = "modern, warm, trustworthy",
     archetype: str | None = None,
 ) -> dict:
     name = (business_name or "").strip()
     domain = (niche or "").strip()
+    audience = (target_audience or "").strip() or f"audiens {domain} Indonesia"
     if not name:
         return {"ok": False, "error": "business_name wajib diisi"}
     if not domain:
@@ -85,6 +87,7 @@ def generate_brand_kit(
         "ok": True,
         "business_name": name,
         "niche": domain,
+        "target_audience": audience,
         "vibe": vibe,
         "archetype": selected_arch,
         "archetype_meta": meta,

--- a/apps/brain_qa/brain_qa/content_planner.py
+++ b/apps/brain_qa/brain_qa/content_planner.py
@@ -33,12 +33,14 @@ def _default_types(channel: str) -> list[str]:
 def generate_content_plan(
     *,
     niche: str,
+    target_audience: str = "",
     duration_days: int = 30,
     channel: str = "instagram",
     cadence_per_week: int = 5,
     objective: str = "awareness",
 ) -> dict:
     clean_niche = (niche or "").strip()
+    clean_audience = (target_audience or "").strip() or f"audiens {clean_niche} Indonesia"
     if not clean_niche:
         return {"ok": False, "error": "niche wajib diisi"}
 
@@ -87,6 +89,7 @@ def generate_content_plan(
     return {
         "ok": True,
         "niche": clean_niche,
+        "target_audience": clean_audience,
         "channel": channel,
         "duration_days": days,
         "cadence_per_week": cadence,

--- a/apps/brain_qa/brain_qa/muhasabah_loop.py
+++ b/apps/brain_qa/brain_qa/muhasabah_loop.py
@@ -46,6 +46,18 @@ def run_muhasabah_loop(
             }
         )
         if gate["total"] >= float(min_score):
+            # Flywheel L1: catat accepted output agar prompt_optimizer bisa belajar
+            try:
+                from .prompt_optimizer import log_accepted_output
+                log_accepted_output(
+                    agent=domain,
+                    prompt_params={"brief": brief},
+                    output_text=current,
+                    score=gate["total"],
+                    domain=domain,
+                )
+            except Exception:
+                pass  # non-blocking
             return {
                 "ok": True,
                 "passed": True,

--- a/brain/public/research_notes/181_sprint6_flywheel_fixes_cron.md
+++ b/brain/public/research_notes/181_sprint6_flywheel_fixes_cron.md
@@ -1,0 +1,101 @@
+---
+id: 181
+title: Sprint 6 — Flywheel L1 Aktif + Signature Fix + Cron Optimizer
+tags: [sprint6, flywheel, prompt_optimizer, brand_builder, content_planner, cron, self-evolution]
+date: 2026-04-21
+---
+
+# Sprint 6 — Flywheel L1 Aktif + Signature Fix + Cron Optimizer
+
+**[FACT]** — Sumber: kode Sprint 5-6 (`muhasabah_loop.py`, `prompt_optimizer.py`, `brand_builder.py`, `content_planner.py`, `agent_serve.py`).
+
+---
+
+## Apa yang Diimplementasikan
+
+### 1. Flywheel L1 Aktif — `muhasabah_loop.py`
+
+**Sebelumnya**: `run_muhasabah_loop()` menjalankan quality gate dan mereturn `passed: True` tapi tidak memberi tahu `prompt_optimizer` bahwa ada output yang bagus.
+
+**Sesudahnya**: saat `gate["total"] >= min_score` (default 7.0), loop otomatis memanggil `log_accepted_output()` sebelum return:
+
+```python
+if gate["total"] >= float(min_score):
+    try:
+        from .prompt_optimizer import log_accepted_output
+        log_accepted_output(
+            agent=domain,
+            prompt_params={"brief": brief},
+            output_text=current,
+            score=gate["total"],
+            domain=domain,
+        )
+    except Exception:
+        pass  # non-blocking
+    return {"ok": True, "passed": True, ...}
+```
+
+**Kenapa penting**: `prompt_optimizer.py` (Sprint 5) sudah siap belajar dari accepted outputs yang dikumpulkan di `.data/accepted_outputs.jsonl`, tapi selama ini tidak ada yang mengisinya secara otomatis. Dengan patch ini, setiap output yang lolos muhasabah langsung masuk ke log → setelah 20 accepted outputs terkumpul, `optimize_prompt()` bisa dijalankan dan membuat prompt template yang lebih baik.
+
+**Arsitektur flywheel**:
+```
+generate_fn(brief)
+  → quality_gate() ← CQF scoring
+  → [jika skor ≥ 7.0] log_accepted_output()  ← BARU
+  → .data/accepted_outputs.jsonl              ← feed
+  → optimize_prompt() (cron Senin 04:00 UTC) ← belajar
+  → template baru → generate_fn lebih pintar ← loop
+```
+
+---
+
+### 2. Signature Fix — `target_audience` Parameter
+
+**Problem**: Sprint 4 membangun `generate_brand_kit()` dan `generate_content_plan()` tanpa parameter `target_audience`. Tapi `prompt_optimizer._BASE_PROMPTS` menyertakan `{target_audience}` di template `brand_builder` dan `content_planner`. Saat optimizer mencoba evaluasi template baru dengan params nyata dari pipeline, ini menyebabkan `KeyError: 'target_audience'`.
+
+**Fix**:
+
+| File | Perubahan |
+|------|-----------|
+| `brand_builder.py` | Tambah `target_audience: str = ""` → default `audiens {niche} Indonesia` |
+| `content_planner.py` | Tambah `target_audience: str = ""` → default `audiens {niche} Indonesia` |
+| `agent_tools.py` | `_tool_generate_brand_kit` pass `target_audience` dari args |
+| `agent_tools.py` | `_tool_generate_content_plan` pass `target_audience` dari args |
+| `agent_tools.py` | ToolSpec params diupdate untuk kedua tool |
+
+**Backward compatible**: parameter opsional dengan default yang sensible → caller lama tidak perlu diubah.
+
+---
+
+### 3. Cron Weekly Endpoint — `agent_serve.py`
+
+Tiga endpoint baru di bawah tag `Creative`:
+
+| Endpoint | Method | Auth | Fungsi |
+|----------|--------|------|--------|
+| `/creative/prompt_optimize/all` | POST | Admin | Jalankan `optimize_all_agents()` — cocok untuk cron |
+| `/creative/prompt_optimize/{agent}` | POST | Admin | Optimalkan satu agent spesifik |
+| `/creative/prompt_optimize/stats` | GET | Public | Baca statistik run terakhir |
+
+**Cron setup di VPS**:
+```cron
+# Senin 04:00 UTC — weekly prompt optimization
+0 4 * * MON curl -s -X POST https://ctrl.sidixlab.com/creative/prompt_optimize/all \
+  -H "X-Admin-Token: $BRAIN_QA_ADMIN_TOKEN" >> /var/log/sidix/prompt_optimize.log 2>&1
+```
+
+---
+
+## Kenapa Urutan Ini Benar
+
+1. **Flywheel tidak ada artinya tanpa data** — patch muhasabah_loop mengisi `.data/accepted_outputs.jsonl` secara otomatis dari production traffic.
+2. **Optimizer tidak bisa belajar dengan parameter salah** — signature fix mencegah `KeyError` saat evaluasi template baru.
+3. **Cron endpoint menyambungkan loop** — data terkumpul selama seminggu → Senin optimizer jalan → template baru aktif → output minggu depan lebih baik.
+
+---
+
+## Keterbatasan
+
+- `min_score = 7.0` di muhasabah_loop adalah hardcoded threshold. Jika `MIN_SAMPLES_TO_OPTIMIZE = 20` belum tercapai, optimizer belum jalan (perlu `force=True` di endpoint).
+- `prompt_params` yang dicatat hanya `{"brief": brief}` — belum capture semua parameter domain-specific (topic, channel, dll). Sprint 7 bisa extend schema ini.
+- Cron endpoint memerlukan `BRAIN_QA_ADMIN_TOKEN` di env VPS. Tanpa ini endpoint return 403.

--- a/docs/LIVING_LOG.md
+++ b/docs/LIVING_LOG.md
@@ -3577,3 +3577,25 @@ Fokus pada "what architecture of knowledge means, not volume of knowledge."
 [NOTE] Kredensial SSH tidak dicatat — hanya dipakai sekali untuk deploy, tidak masuk ke file apapun.
 
 [NOTE] Sprint 5 worktree: D:\MIGHAN Model\sprint5\ — branch feat/sprint5-agency-kit. File baru: llm_judge.py, agent_tools.py (copy+extend dari main), agent_serve.py (copy+extend).
+
+## 2026-04-21 — Sprint 6 Quick Wins
+
+### T6.1 — Flywheel L1 Aktif
+[IMPL] `muhasabah_loop.py` — patch `run_muhasabah_loop()`: saat `gate["total"] >= min_score`, otomatis memanggil `log_accepted_output(agent=domain, ...)` sebelum return. Non-blocking (try/except pass). Ini mengaktifkan data flywheel L1 yang sudah disiapkan Sprint 5 — accepted outputs kini otomatis masuk ke `.data/accepted_outputs.jsonl` tanpa intervensi manual.
+
+### T6.2 — Signature Fix Sprint 4
+[FIX] `brand_builder.py` — tambah parameter `target_audience: str = ""` ke `generate_brand_kit()`. Default: `audiens {niche} Indonesia`. Output dict juga menyertakan field `target_audience`. Root cause: Sprint 4 tidak implementasikan param ini meski `prompt_optimizer._BASE_PROMPTS["brand_builder"]` sudah menyertakan `{target_audience}` di template — menyebabkan `KeyError` saat optimizer mencoba evaluasi template baru.
+
+[FIX] `content_planner.py` — tambah parameter `target_audience: str = ""` ke `generate_content_plan()`. Default: `audiens {niche} Indonesia`. Output dict juga menyertakan field `target_audience`.
+
+[FIX] `agent_tools.py` — `_tool_generate_brand_kit` dan `_tool_generate_content_plan` kini mem-pass `target_audience` dari args ke function. ToolSpec `params` list diupdate untuk kedua tool. Backward compatible — caller lama tetap berfungsi.
+
+### T6.3 — Cron Weekly Optimizer
+[IMPL] `agent_serve.py` — tambah 3 endpoint baru tag `Creative`:
+- `POST /creative/prompt_optimize/all` — jalankan `optimize_all_agents()`, admin-only. Dilengkapi docstring cron example: `0 4 * * MON curl -s -X POST https://ctrl.sidixlab.com/creative/prompt_optimize/all -H "X-Admin-Token: $BRAIN_QA_ADMIN_TOKEN"`.
+- `POST /creative/prompt_optimize/{agent}` — optimalkan satu agent spesifik, admin-only.
+- `GET /creative/prompt_optimize/stats` — baca stats run terakhir, public.
+
+[DOC] `brain/public/research_notes/181_sprint6_flywheel_fixes_cron.md` — dokumentasi lengkap: arsitektur flywheel, tabel signature fix, cron setup, keterbatasan.
+
+[DECISION] Cron `/creative/prompt_optimize/all` diset Senin 04:00 UTC (bukan harian) karena `MIN_SAMPLES_TO_OPTIMIZE=20` perlu waktu terkumpul dari production traffic. Weekly cukup untuk iterasi L1.


### PR DESCRIPTION
## Summary

- **T6.1** `muhasabah_loop.py` — auto-call `log_accepted_output()` saat CQF >= 7.0, mengaktifkan data flywheel L1 (prompt_optimizer Sprint 5 sebelumnya idle karena tidak ada yang mengisi `.data/accepted_outputs.jsonl`)
- **T6.2** Signature fix: `generate_brand_kit()` dan `generate_content_plan()` kini menerima `target_audience` (opsional, backward-compatible). Fix KeyError saat prompt_optimizer evaluasi template dengan params nyata dari pipeline.
- **T6.3** `agent_serve.py` — 3 endpoint baru: `POST /creative/prompt_optimize/all` (cron Senin 04:00 UTC), `POST /creative/prompt_optimize/{agent}`, `GET /creative/prompt_optimize/stats`
- **DOC** Research note `181_sprint6_flywheel_fixes_cron.md` + LIVING_LOG Sprint 6 entries

## Cron Setup (setelah merge + deploy VPS)

```
0 4 * * MON curl -s -X POST https://ctrl.sidixlab.com/creative/prompt_optimize/all -H "X-Admin-Token: $BRAIN_QA_ADMIN_TOKEN"
```

## Test plan

- [ ] Import test: `python -c "from brain_qa.muhasabah_loop import run_muhasabah_loop; print('OK')"`
- [ ] Signature test: `from brain_qa.brand_builder import generate_brand_kit; generate_brand_kit(business_name="X", niche="Y", target_audience="Z")`
- [ ] Endpoint test setelah deploy: `curl -X GET https://ctrl.sidixlab.com/creative/prompt_optimize/stats`

Generated with Claude Code
